### PR TITLE
Adjusted installation from 'pip3 install' to 'python3 -m pip install'

### DIFF
--- a/content/cve/cve-2016-1287/index.md
+++ b/content/cve/cve-2016-1287/index.md
@@ -18,7 +18,7 @@ git clone https://github.com/NetSPI/asa_tools.git
 ```
 
 ```plain
-pip3 install hexdump
+python3 -m pip install hexdump
 ```
 
 ### Usage

--- a/content/cve/cve-2019-19781/index.md
+++ b/content/cve/cve-2019-19781/index.md
@@ -18,7 +18,7 @@ git clone https://github.com/cisagov/check-cve-2019-19781.git
 ```
 
 ```plain
-pip3 install -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 ### Usage

--- a/content/tools/automation/ansible/index.md
+++ b/content/tools/automation/ansible/index.md
@@ -16,7 +16,7 @@ Simple, agentless IT automation that anyone can use - Define and run a single ta
 ### Installation
 
 ```plain
-pip3 install ansible
+python3 -m pip install ansible
 ```
 
 ### Usage

--- a/content/tools/forensics/stegcracker/index.md
+++ b/content/tools/forensics/stegcracker/index.md
@@ -18,7 +18,7 @@ Please use [Stegeek]({{< ref "stegseek" >}}), newer and quicker.
 ### Installation
 
 ```plain
-pip3 install stegcracker
+python3 -m pip install stegcracker
 ```
 
 ### Usage

--- a/content/tools/forensics/usbrip/index.md
+++ b/content/tools/forensics/usbrip/index.md
@@ -16,7 +16,7 @@ A simple forensics tool with command line interface that lets you keep track of 
 ### Installation
 
 ```plain
-pip3 install usbrip
+python3 -m pip install usbrip
 ```
 
 ### Usage

--- a/content/tools/framework/bloodhoundpy/index.md
+++ b/content/tools/framework/bloodhoundpy/index.md
@@ -16,13 +16,13 @@ tags : ['Framework', 'Active Directory']
 ```plain
 git clone https://github.com/fox-it/BloodHound.py.git
 cd BloodHound.py
-pip3 install .
+python3 -m pip install .
 ```
 
 Or via Python-PIP.
 
 ```plain
-pip3 install bloodhound
+python3 -m pip install bloodhound
 ```
 
 ### Usage

--- a/content/tools/framework/donpapi/index.md
+++ b/content/tools/framework/donpapi/index.md
@@ -59,7 +59,7 @@ With a user password, or the domain PVK we can unprotect the user's DPAPI secret
 
 ```plain
 git clone https://github.com/login-securite/DonPAPI.git
-pip3 install -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 ### Usage

--- a/content/tools/framework/impacket/_index.md
+++ b/content/tools/framework/impacket/_index.md
@@ -24,7 +24,7 @@ git clone https://github.com/SecureAuthCorp/impacket.git
 ```
 
 ```plain
-sudo pip3 install .
+sudo python3 -m pip install .
 ```
 
 ### URL list

--- a/content/tools/framework/mitm6/index.md
+++ b/content/tools/framework/mitm6/index.md
@@ -16,7 +16,7 @@ weight : 0
 ### Installation
 
 ```plain
-sudo pip3 install mitm6
+sudo python3 -m pip install mitm6
 ```
 
 ### Usage

--- a/content/tools/framework/pypykatz/index.md
+++ b/content/tools/framework/pypykatz/index.md
@@ -16,7 +16,7 @@ Mimikatz implementation in pure Python. At least a part of it :)
 ### Installation
 
 ```plain
-pip3 install pypykatz
+python3 -m pip install pypykatz
 ```
 
 ### Usage

--- a/content/tools/hash-cracking/pack/index.md
+++ b/content/tools/hash-cracking/pack/index.md
@@ -26,7 +26,7 @@ pip install pyenchant==3.0.0a1
 
 ```plain
 git clone https://github.com/Hydraze/pack
-pip3 install pyenchant
+python3 -m pip install pyenchant
 ```
 
 ### Examples

--- a/content/tools/hash-cracking/search-that-hash/index.md
+++ b/content/tools/hash-cracking/search-that-hash/index.md
@@ -16,7 +16,7 @@ Tired of going to every website to crack your hash? Search-That-Hash automates t
 ### Installation
 
 ```plain
-pip3 install search-that-hash && sth
+python3 -m pip install search-that-hash && sth
 ```
 
 ### Usage

--- a/content/tools/m365/azuread-sso-brute/index.md
+++ b/content/tools/m365/azuread-sso-brute/index.md
@@ -17,7 +17,7 @@ Python tool to brute force against an AzureAD SSO endpoint.
 
 ```plain
 git clone https://github.com/thijsvos/aad_sso_brute.git
-pip3 install -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 ### Usage

--- a/content/tools/m365/credmaster/index.md
+++ b/content/tools/m365/credmaster/index.md
@@ -47,7 +47,7 @@ For detection tips, see the blogpost and detection section.
 
 ```plain
 git clone https://github.com/knavesec/CredMaster.git
-pip3 install -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 #### Requirements

--- a/content/tools/m365/m365_groups_enum/index.md
+++ b/content/tools/m365/m365_groups_enum/index.md
@@ -17,7 +17,7 @@ Enumerate Microsoft 365 Groups in a tenant with their metadata.
 
 ```plain
 git clone https://github.com/cnotin/m365_groups_enum.git
-pip3 install -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 ### Usage

--- a/content/tools/m365/o365spray/index.md
+++ b/content/tools/m365/o365spray/index.md
@@ -19,7 +19,7 @@ o365spray a username enumeration and password spraying tool aimed at Microsoft O
 
 ```plain
 git clone https://github.com/0xZDH/o365spray
-pip3 install -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 ### Usage

--- a/content/tools/m365/roadrecon/index.md
+++ b/content/tools/m365/roadrecon/index.md
@@ -16,7 +16,7 @@ Rogue Office 365 and Azure AD (active) Directory tools - ROADtools is a framewor
 ### Installation
 
 ```plain
-pip3 install roadrecon
+python3 -m pip install roadrecon
 ```
 
 ### Usage

--- a/content/tools/networking/dnsdiag/index.md
+++ b/content/tools/networking/dnsdiag/index.md
@@ -44,7 +44,7 @@ Check out the [git repository](https://github.com/farrokhi/dnsdiag) and install 
 ```plain
 git clone https://github.com/farrokhi/dnsdiag.git
 cd dnsdiag
-pip3 install -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 #### pip3
@@ -52,7 +52,7 @@ pip3 install -r requirements.txt
 You can alternatively install the package using pip:
 
 ```plain
-pip3 install dnsdiag
+python3 -m pip install dnsdiag
 ```
 
 #### Binary Package

--- a/content/tools/osint/crosslinked/index.md
+++ b/content/tools/osint/crosslinked/index.md
@@ -22,7 +22,7 @@ git clone https://github.com/m8r0wn/CrossLinked.git
 Install requirements
 
 ```plain
-pip3 install -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 ### Usage

--- a/content/tools/osint/dirhunt/index.md
+++ b/content/tools/osint/dirhunt/index.md
@@ -38,7 +38,7 @@ Read more about how to use Dirhunt [in the documentation](http://docs.nekmo.org/
 ### Installation
 
 ```plain
-pip3 install dirhunt
+python3 -m pip install dirhunt
 ```
 
 There are other [installation methods](http://docs.nekmo.org/dirhunt/installation.html) available.

--- a/content/tools/osint/emailfinder/index.md
+++ b/content/tools/osint/emailfinder/index.md
@@ -16,7 +16,7 @@ Search emails through Search Engines.
 ### Installation
 
 ```plain
-pip3 install emailfinder
+python3 -m pip install emailfinder
 ```
 
 ### Usage

--- a/content/tools/osint/h8mail/index.md
+++ b/content/tools/osint/h8mail/index.md
@@ -16,7 +16,7 @@ An email OSINT and breach hunting tool using different breach and reconnaissance
 ### Installation
 
 ```plain
-pip3 install h8mail
+python3 -m pip install h8mail
 ```
 
 ### Usage

--- a/content/tools/osint/l33tlinked/index.md
+++ b/content/tools/osint/l33tlinked/index.md
@@ -20,7 +20,7 @@ Welcome to my modification of CrossLinked (Can be found [here](https://github.co
 ```plain
 git clone https://github.com/Sq00ky/L33tLinked.git
 cd L33tLinked
-pip3 install -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 ### Usage

--- a/content/tools/osint/pymeta/index.md
+++ b/content/tools/osint/pymeta/index.md
@@ -22,7 +22,7 @@ sudo python3 setup.py install
 ```
 
 ```plain
-pip3 install pymetadata
+python3 -m pip install pymetadata
 ```
 
 ### Usage

--- a/content/tools/osint/recon-ng/index.md
+++ b/content/tools/osint/recon-ng/index.md
@@ -26,7 +26,7 @@ sudo apt install recon-ng
 ```plain
 git clone https://github.com/lanmaster53/recon-ng.git
 cd recon-ng
-pip3 install -r REQUIREMENTS
+python3 -m pip install -r REQUIREMENTS
 ```
 
 ### Usage (recon-ng)

--- a/content/tools/osint/socialscan/index.md
+++ b/content/tools/osint/socialscan/index.md
@@ -16,7 +16,7 @@ Command-line interface for checking email address and username usage on online p
 ### Installation
 
 ```plain
-pip3 install socialscan
+python3 -m pip install socialscan
 ```
 
 ### Usage

--- a/content/tools/osint/spiderfoot/index.md
+++ b/content/tools/osint/spiderfoot/index.md
@@ -73,7 +73,7 @@ SpiderFoot's 200+ modules feed each other in a publisher/subscriber model to ens
 wget https://github.com/smicallef/spiderfoot/archive/v3.3.tar.gz
 tar zxvf v3.3.tar.gz
 cd spiderfoot
-pip3 install -r requirements.txt
+python3 -m pip install -r requirements.txt
 python3 ./sf.py -l 127.0.0.1:5001
 ```
 
@@ -82,7 +82,7 @@ python3 ./sf.py -l 127.0.0.1:5001
 ```plain
 git clone https://github.com/smicallef/spiderfoot.git
 cd spiderfoot
-pip3 install -r requirements.txt
+python3 -m pip install -r requirements.txt
 python3 ./sf.py -l 127.0.0.1:5001
 ```
 

--- a/content/tools/osint/sublist3r/index.md
+++ b/content/tools/osint/sublist3r/index.md
@@ -17,7 +17,7 @@ Python tool designed to enumerate subdomains of websites using OSINT.
 
 ```plain
 git clone https://github.com/aboul3la/Sublist3r.git
-pip3 install -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 ### Usage

--- a/content/tools/other/adexplorersnapshotpy/index.md
+++ b/content/tools/other/adexplorersnapshotpy/index.md
@@ -26,7 +26,7 @@ The ingestor only supports offline information collection from the snapshot file
 ```plain
 git clone https://github.com/c3c/ADExplorerSnapshot.py.git
 cd ADExplorerSnapshot.py
-pip3 install --user .
+python3 -m pip install --user .
 ```
 
 ### Usage

--- a/content/tools/other/camover/index.md
+++ b/content/tools/other/camover/index.md
@@ -24,7 +24,7 @@ Tool effectively looks for `http://{address}/system.ini?loginuse&loginpas` and r
 ### Installation
 
 ```plain
-pip3 install git+https://github.com/EntySec/CamOver
+python3 -m pip install git+https://github.com/EntySec/CamOver
 ```
 
 ### Usage

--- a/content/tools/other/ccat/index.md
+++ b/content/tools/other/ccat/index.md
@@ -18,7 +18,7 @@ This tool is designed to analyze the configuration files of Cisco devices. The [
 
 ```plain
 git clone https://github.com/frostbits-security/ccat.git
-pip3 install -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 ### Usage

--- a/content/tools/other/checkdmarc/index.md
+++ b/content/tools/other/checkdmarc/index.md
@@ -16,7 +16,7 @@ Validates and parses SPF amd DMARC DNS records.
 ### Installation
 
 ```plain
-pip3 install checkdmarc
+python3 -m pip install checkdmarc
 ```
 
 ### Usage

--- a/content/tools/other/dnstwist/index.md
+++ b/content/tools/other/dnstwist/index.md
@@ -18,7 +18,7 @@ Domain name permutation engine for detecting homograph phishing attacks, typosqu
 ```plain
 git clone https://github.com/elceef/dnstwist.git
 cd dnstwist
-pip3 install .
+python3 -m pip install .
 ```
 
 ### Usage

--- a/content/tools/other/emailseccheck/index.md
+++ b/content/tools/other/emailseccheck/index.md
@@ -29,7 +29,7 @@ Email spoofing is identified under the following conditions:
 
 ```plain
 git clone https://github.com/MarkoH17/EmailSecCheck.git
-pip3 install -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 ### Usage

--- a/content/tools/other/fawkes/index.md
+++ b/content/tools/other/fawkes/index.md
@@ -18,7 +18,7 @@ Tool to search for targets vulnerable to SQL Injection. Performs the search usin
 ```plain
 git clone https://github.com/0xdutra/fawkes
 cd fawkes
-pip3 install -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 ### Usage

--- a/content/tools/other/git-dumper/index.md
+++ b/content/tools/other/git-dumper/index.md
@@ -16,7 +16,7 @@ A tool to dump a git repository from a website.
 ### Installation
 
 ```plain
-pip3 install git-dumper
+python3 -m pip install git-dumper
 ```
 
 ### Usage

--- a/content/tools/other/ldapdomaindump/index.md
+++ b/content/tools/other/ldapdomaindump/index.md
@@ -18,7 +18,7 @@ Active Directory information dumper via LDAP.
 Dependencies
 
 ```plain
-pip3 install ldap3 dnspython
+python3 -m pip install ldap3 dnspython
 ```
 
 ```plain

--- a/content/tools/other/pcredz/index.md
+++ b/content/tools/other/pcredz/index.md
@@ -37,7 +37,7 @@ This tool extracts Credit card numbers, NTLM(DCE-RPC, HTTP, SQL, LDAP, etc), Ker
 #### Requirements
 
 ```plain
-apt install python3-pip && sudo apt-get install libpcap-dev && pip3 install Cython && pip3 install python-libpcap
+apt install python3-pip && sudo apt-get install libpcap-dev && python3 -m pip install Cython && python3 -m pip install python-libpcap
 ```
 
 #### Download tool

--- a/content/tools/other/pywhat/index.md
+++ b/content/tools/other/pywhat/index.md
@@ -20,7 +20,7 @@ Well, with `what` all you have to do is ask what "0x52908400098527886E0F70300698
 ### Installation
 
 ```plain
-pip3 install pywhat
+python3 -m pip install pywhat
 ```
 
 For macOS you can also install using HomeBrew.

--- a/content/tools/other/qobuz-dl/index.md
+++ b/content/tools/other/qobuz-dl/index.md
@@ -30,7 +30,7 @@ Search, explore and download Lossless and Hi-Res music from Qobuz - The ultimate
 ### Installation
 
 ```plain
-pip3 install --upgrade qobuz-dl
+python3 -m pip install --upgrade qobuz-dl
 ```
 
 ### Usage

--- a/content/tools/other/rdpassspray/index.md
+++ b/content/tools/other/rdpassspray/index.md
@@ -20,7 +20,7 @@ Is a python tool to perform password spray attack in a Microsoft domain environm
 ```plain
 git clone https://github.com/xFreed0m/RDPassSpray.git
 cd RDPassSpray
-pip3 install -r requirements.txt
+python3 -m pip install -r requirements.txt
 sudo apt install freerdp2-x11
 ```
 

--- a/content/tools/other/rombuster/index.md
+++ b/content/tools/other/rombuster/index.md
@@ -22,7 +22,7 @@ Is a router exploitation tool that allows to disclosure network router admin pas
 ### Installation
 
 ```plain
-pip3 install git+https://github.com/EntySec/RomBuster
+python3 -m pip install git+https://github.com/EntySec/RomBuster
 ```
 
 ### Usage

--- a/content/tools/other/rsactftool/index.md
+++ b/content/tools/other/rsactftool/index.md
@@ -18,7 +18,7 @@ RSA multi attacks tool : uncipher data from weak public key and try to recover p
 ```plain
 git clone https://github.com/Ganapati/RsaCtfTool.git
 sudo apt-get install libgmp3-dev libmpc-dev
-pip3 install -r "requirements.txt"
+python3 -m pip install -r "requirements.txt"
 python3 RsaCtfTool.py
 ```
 

--- a/content/tools/other/updog/index.md
+++ b/content/tools/other/updog/index.md
@@ -18,7 +18,7 @@ Local file sharing made easy.
 ### Installation
 
 ```plain
-pip3 install updog
+python3 -m pip install updog
 ```
 
 ### Usage

--- a/content/tools/other/woeusb-ng/index.md
+++ b/content/tools/other/woeusb-ng/index.md
@@ -22,7 +22,7 @@ sudo apt install git p7zip-full python3-pip python3-wxgtk4.0 grub2-common
 ```
 
 ```plain
-sudo pip3 install WoeUSB-ng
+sudo python3 -m pip install WoeUSB-ng
 ```
 
 ### Examples


### PR DESCRIPTION
To ensure the correct installation of Python is used to install the package, call it with `python3 -m pip` instead of `pip3`