### PR TITLE
Improve KB discoverability and validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Check local environment
+        run: npm run doctor
+
+      - name: Run unit tests
+        run: npm test
+
       - name: Check Astro project
         run: npm run check
 

--- a/.github/workflows/external-links.yml
+++ b/.github/workflows/external-links.yml
@@ -1,0 +1,31 @@
+name: Check external links
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '33 7 * * 3'
+
+permissions:
+  contents: read
+
+jobs:
+  links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone this repo
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .node-version
+
+      - name: Check external links
+        run: node scripts/check-external-links.mjs --output .reports/external-links.md
+
+      - name: Upload link health report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: external-link-health
+          path: .reports/external-links.md

--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ $RECYCLE.BIN/
 .hugo_build.lock
 .sync
 .rumdl_cache/
+.reports/
 codex.resume
 !/public/_headers
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ npm run check:content
 npm run check:links
 npm run audit:known
 npm run sysinternals:check
+npm test
+npm run doctor
 npm run build
 npm run smoke
 npm run validate
@@ -40,6 +42,17 @@ intentional mirror/bulk asset listed in `scripts/content-policy.json`.
 `npm run check:links` validates internal Markdown links, anchors, images, and
 downloadable assets. External links are inventoried without network calls.
 `npm run validate` runs the full local validation gate.
+
+`npm test` runs focused parser and content-contract tests. `npm run doctor`
+checks the Node.js version, required project paths, and local npm availability.
+
+The scheduled `Check external links` workflow creates a report of reachable
+external URLs without blocking content builds.
+
+Content pages may optionally define `lastReviewed` (`YYYY-MM-DD`), `status`
+(`active`, `deprecated`, or `archived`), and `platforms` (a string or list of
+strings). These fields power freshness and compatibility hints without being
+required for existing pages.
 
 Use `npm run sysinternals:check` to compare the published Sysinternals files
 with `https://live.sysinternals.com/`. Use `npm run sysinternals:sync` to

--- a/package.json
+++ b/package.json
@@ -13,10 +13,12 @@
     "check:links": "node scripts/check-links.mjs",
     "check:outdated": "node scripts/check-outdated.mjs",
     "audit:known": "node scripts/check-audit.mjs",
+    "doctor": "node scripts/doctor.mjs",
+    "test": "node --test test/*.test.mjs",
     "sysinternals:check": "node scripts/sync-sysinternals.mjs --check",
     "sysinternals:sync": "node scripts/sync-sysinternals.mjs --write",
     "smoke": "node scripts/smoke-build.mjs",
-    "validate": "npm run check && npm run check:content && npm run check:links && npm run build && npm run check:assets && npm run smoke && npm run audit:known"
+    "validate": "npm run doctor && npm test && npm run check && npm run check:content && npm run check:links && npm run build && npm run check:assets && npm run smoke && npm run audit:known"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.10",

--- a/scripts/check-content.mjs
+++ b/scripts/check-content.mjs
@@ -26,6 +26,7 @@ const reportedExtensions = new Set([
   ".tgz",
   ".zip"
 ]);
+const pageStatuses = new Set(["active", "deprecated", "archived"]);
 const percentShortcodes = new Set(["children", "notice", "resources", "attachments"]);
 const angleShortcodes = new Set(["ref", "youtube", "gist"]);
 
@@ -131,6 +132,30 @@ function validatePages() {
     if (page.frontmatter.weight !== undefined && !Number.isFinite(Number(page.frontmatter.weight))) {
       errors.push(`${page.relativeFile}: weight must be numeric`);
     }
+
+    for (const field of ["date", "lastReviewed"]) {
+      if (
+        page.frontmatter[field] !== undefined &&
+        !isDateValue(page.frontmatter[field])
+      ) {
+        errors.push(`${page.relativeFile}: ${field} must use YYYY-MM-DD`);
+      }
+    }
+
+    if (
+      page.frontmatter.status !== undefined &&
+      !pageStatuses.has(String(page.frontmatter.status).trim().toLowerCase())
+    ) {
+      errors.push(`${page.relativeFile}: status must be active, deprecated, or archived`);
+    }
+
+    if (page.frontmatter.platforms !== undefined) {
+      const platforms = page.frontmatter.platforms;
+      const valid =
+        typeof platforms === "string" ||
+        (Array.isArray(platforms) && platforms.every((platform) => typeof platform === "string"));
+      if (!valid) errors.push(`${page.relativeFile}: platforms must be a string or string array`);
+    }
   }
 
   for (const [url, files] of urls) {
@@ -138,6 +163,11 @@ function validatePages() {
       errors.push(`duplicate URL ${url}: ${files.join(", ")}`);
     }
   }
+}
+
+function isDateValue(value) {
+  if (value instanceof Date) return !Number.isNaN(value.getTime());
+  return /^\d{4}-\d{2}-\d{2}(?:$|[T\s])/.test(String(value).trim());
 }
 
 function validateRefsAndShortcodes() {

--- a/scripts/check-external-links.mjs
+++ b/scripts/check-external-links.mjs
@@ -1,0 +1,105 @@
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const root = process.cwd();
+const args = process.argv.slice(2);
+const output = valueAfter("--output") ?? "external-links-report.md";
+const timeoutMs = Number(valueAfter("--timeout") ?? 10000);
+const concurrency = Math.max(1, Number(valueAfter("--concurrency") ?? 8));
+const urls = new Set();
+
+await collectMarkdown(path.join(root, "content"));
+await collectFile(path.join(root, "README.md"));
+
+const uniqueUrls = [...urls].sort();
+const results = [];
+let cursor = 0;
+
+async function worker() {
+  while (cursor < uniqueUrls.length) {
+    const index = cursor++;
+    results[index] = await checkUrl(uniqueUrls[index]);
+  }
+}
+
+await Promise.all(Array.from({ length: Math.min(concurrency, uniqueUrls.length) }, worker));
+results.sort((a, b) => a.url.localeCompare(b.url));
+
+const failures = results.filter((result) => result.error || result.status >= 400);
+const lines = [
+  "# External link health",
+  "",
+  `Checked: ${results.length}`,
+  `Generated: ${new Date().toISOString()}`,
+  `Failures: ${failures.length}`,
+  ""
+];
+
+if (failures.length) {
+  lines.push("| URL | Result | Detail |", "| --- | --- | --- |");
+  for (const result of failures) {
+    const detail = result.error ?? `HTTP ${result.status}`;
+    lines.push(`| ${result.url} | failed | ${detail.replaceAll("|", "\\|")} |`);
+  }
+} else {
+  lines.push("All checked external links responded successfully.");
+}
+
+await mkdir(path.dirname(path.resolve(root, output)), { recursive: true });
+await writeFile(path.resolve(root, output), `${lines.join("\n")}\n`);
+
+console.log(`Checked ${results.length} external link(s); ${failures.length} failure(s)`);
+
+async function collectMarkdown(directory) {
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const absolute = path.join(directory, entry.name);
+    if (entry.isDirectory()) await collectMarkdown(absolute);
+    else if (entry.name.endsWith(".md")) await collectFile(absolute);
+  }
+}
+
+async function collectFile(file) {
+  const source = await readFile(file, "utf8");
+  const matches = source.matchAll(/https?:\/\/[^\s<>"')\]]+/gi);
+  for (const match of matches) {
+    const clean = match[0].replace(/[.,;:!?]+$/, "");
+    if (clean) urls.add(clean);
+  }
+}
+
+async function checkUrl(url) {
+  try {
+    const head = await request(url, "HEAD");
+    if (head.status !== 405 && head.status !== 403) return { url, status: head.status };
+    const get = await request(url, "GET");
+    return { url, status: get.status };
+  } catch (error) {
+    return { url, error: error.message };
+  }
+}
+
+async function request(url, method) {
+  const response = await fetch(url, {
+    method,
+    redirect: "follow",
+    signal: AbortSignal.timeout(timeoutMs),
+    headers: {
+      "user-agent": "kb-external-link-check/1.0",
+      ...(method === "GET" ? { range: "bytes=0-0" } : {})
+    }
+  });
+  response.body?.cancel();
+  return response;
+}
+
+function valueAfter(name) {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] : undefined;
+}

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -1,0 +1,41 @@
+import { access, readFile } from "node:fs/promises";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+const root = process.cwd();
+const requiredFiles = [
+  ".node-version",
+  "package.json",
+  "package-lock.json",
+  "astro.config.mjs",
+  "content",
+  "src"
+];
+const errors = [];
+
+for (const file of requiredFiles) {
+  try {
+    await access(path.join(root, file));
+  } catch {
+    errors.push(`missing required project path: ${file}`);
+  }
+}
+
+const expectedNode = (await readFile(path.join(root, ".node-version"), "utf8")).trim();
+const actualNode = process.versions.node;
+if (expectedNode && !actualNode.startsWith(`${expectedNode}.`) && actualNode !== expectedNode) {
+  errors.push(`Node.js ${actualNode} is active; .node-version requires ${expectedNode}`);
+}
+
+try {
+  execFileSync("npm", ["--version"], { stdio: "ignore" });
+} catch {
+  errors.push("npm is not available on PATH");
+}
+
+if (errors.length) {
+  for (const error of errors) console.error(`error: ${error}`);
+  process.exitCode = 1;
+} else {
+  console.log(`Environment ready: Node.js ${actualNode}`);
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,12 @@
 ---
 import "../styles/global.css";
-import { getAllTags, getDescendantLeafCount, getRootSections, tagSlug, type KbPage } from "@lib/content";
+import {
+  getDescendantLeafCount,
+  getPopularTags,
+  getRootSections,
+  tagSlug,
+  type KbPage
+} from "@lib/content";
 
 type Props = {
   page?: KbPage;
@@ -10,7 +16,7 @@ type Props = {
 
 const { page, title, description = "" } = Astro.props;
 const sections = getRootSections();
-const tags = getAllTags().slice(0, 18);
+const tags = getPopularTags();
 const canonical = new URL(Astro.url.pathname, "https://kb.offsec.nl").toString();
 const activeUrl = page?.url ?? Astro.url.pathname;
 const currentYear = new Date().getFullYear();
@@ -62,10 +68,21 @@ function renderNav(items: KbPage[], level = 0): string {
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content={description || "Offensive security knowledge base"} />
     <link rel="canonical" href={canonical} />
+    <meta property="og:title" content={`${title} :: Knowledge Base`} />
+    <meta property="og:description" content={description || "Offensive security knowledge base"} />
+    <meta property="og:type" content={page?.url && page.url !== "/" ? "article" : "website"} />
+    <meta property="og:url" content={canonical} />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content={`${title} :: Knowledge Base`} />
+    <meta name="twitter:description" content={description || "Offensive security knowledge base"} />
+    {(page?.lastReviewed || page?.date) && (
+      <meta property="article:modified_time" content={page.lastReviewed || page.date} />
+    )}
     <link rel="icon" href="/images/favicon.png" />
     <title>{title} :: Knowledge Base</title>
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to content</a>
     <div class="app-shell">
       <aside class="sidebar" id="site-sidebar">
         <a class="brand" href="/" aria-label="Knowledge Base home">
@@ -101,7 +118,14 @@ function renderNav(items: KbPage[], level = 0): string {
 
       <div class="main-column">
         <header class="topbar">
-          <button class="icon-button" type="button" data-sidebar-toggle aria-label="Toggle navigation">
+          <button
+            class="icon-button"
+            type="button"
+            data-sidebar-toggle
+            aria-label="Toggle navigation"
+            aria-controls="site-sidebar"
+            aria-expanded="false"
+          >
             <span></span><span></span><span></span>
           </button>
           <div class="crumbs">
@@ -118,11 +142,21 @@ function renderNav(items: KbPage[], level = 0): string {
           </a>
         </header>
 
-        <main class="page-frame">
+        <main class="page-frame" id="main-content" tabindex="-1">
           <header class="page-header">
             <div class="eyebrow">::{page?.section || "index"}</div>
             <h1>{title || "Knowledge Base"}</h1>
             {description && <p>{description}</p>}
+            {page && (page.date || page.lastReviewed || page.status || page.platforms.length) ? (
+              <dl class="page-meta" aria-label="Page metadata">
+                {page.date && <div><dt>Updated</dt><dd>{page.date}</dd></div>}
+                {page.lastReviewed && <div><dt>Reviewed</dt><dd>{page.lastReviewed}</dd></div>}
+                {page.status && page.status !== "active" && (
+                  <div><dt>Status</dt><dd><span class={`status-badge status-${page.status}`}>{page.status}</span></dd></div>
+                )}
+                {page.platforms.length > 0 && <div><dt>Platforms</dt><dd>{page.platforms.join(", ")}</dd></div>}
+              </dl>
+            ) : null}
             {page?.tags.length ? (
               <div class="tag-row">
                 {page.tags.map((tag) => <a href={`/tags/${tagSlug(tag)}/`}>#{tag}</a>)}
@@ -134,15 +168,32 @@ function renderNav(items: KbPage[], level = 0): string {
       </div>
     </div>
 
-    <dialog class="search-dialog" data-search-dialog>
+    <dialog class="search-dialog" data-search-dialog aria-labelledby="search-dialog-title">
       <form method="dialog">
-        <button aria-label="Close search">x</button>
+        <button type="submit" aria-label="Close search">x</button>
       </form>
-      <label>
+      <h2 id="search-dialog-title" class="visually-hidden">Search knowledge base</h2>
+      <label for="search-input">
         <span>query</span>
-        <input data-search-input autocomplete="off" spellcheck="false" placeholder="tool, command, CVE, technique" />
+        <input id="search-input" data-search-input autocomplete="off" spellcheck="false" placeholder="tool, command, CVE, technique" aria-controls="search-results" />
       </label>
-      <div class="search-results" data-search-results></div>
+      <div class="search-filters" aria-label="Search filters">
+        <label>
+          <span>section</span>
+          <select data-search-section>
+            <option value="">all sections</option>
+            {sections.map((section) => <option value={section.section}>{section.title}</option>)}
+          </select>
+        </label>
+        <label>
+          <span>tag</span>
+          <select data-search-tag>
+            <option value="">all tags</option>
+            {tags.map((item) => <option value={item.tag}>{item.tag} ({item.count})</option>)}
+          </select>
+        </label>
+      </div>
+      <div class="search-results" id="search-results" data-search-results aria-live="polite" aria-label="Search results"></div>
     </dialog>
 
     <script is:inline src="/js/kb-app.js" defer></script>

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -19,6 +19,9 @@ export type KbPage = {
   frontmatter: Record<string, any>;
   weight: number;
   date?: string;
+  lastReviewed?: string;
+  status?: "active" | "deprecated" | "archived";
+  platforms: string[];
   tags: string[];
   parentUrl: string | null;
   section: string;
@@ -104,11 +107,45 @@ export function getAllTags() {
   return [...tags.values()].sort((a, b) => a.tag.localeCompare(b.tag));
 }
 
+export function getPopularTags(limit = 18) {
+  return getAllTags()
+    .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
+    .slice(0, limit);
+}
+
 export function getPagesByTag(tag: string) {
   const requested = tagSlug(tag);
   return getPages()
     .filter((page) => page.tags.some((item) => tagSlug(item) === requested))
     .sort(sortPages);
+}
+
+export function getRelatedPages(page: KbPage, limit = 4) {
+  const pageTags = new Set(page.tags.map(tagSlug));
+
+  return getPages()
+    .filter((candidate) => candidate.url !== page.url && candidate.frontmatter.hidden !== true)
+    .map((candidate) => {
+      const sharedTags = candidate.tags.filter((tag) => pageTags.has(tagSlug(tag))).length;
+      const sameSection = candidate.section === page.section ? 2 : 0;
+      return { candidate, score: sharedTags * 4 + sameSection };
+    })
+    .filter(({ score }) => score > 0)
+    .sort((a, b) => b.score - a.score || sortPages(a.candidate, b.candidate))
+    .slice(0, limit)
+    .map(({ candidate }) => candidate);
+}
+
+export function getPageNeighbors(page: KbPage) {
+  getPages();
+  const siblings = (page.parentUrl ? urlMap?.get(page.parentUrl)?.children : getRootSections()) ?? [];
+  const visible = siblings.filter((item) => item.frontmatter.hidden !== true).sort(sortPages);
+  const index = visible.findIndex((item) => item.url === page.url);
+
+  return {
+    previous: index > 0 ? visible[index - 1] : undefined,
+    next: index >= 0 && index < visible.length - 1 ? visible[index + 1] : undefined
+  };
 }
 
 export function renderPage(page: KbPage) {
@@ -149,7 +186,10 @@ function parsePage(file: string): KbPage {
     body: parsed.content.trim(),
     frontmatter: parsed.data,
     weight: Number(parsed.data.weight ?? Number.MAX_SAFE_INTEGER),
-    date: parsed.data.date ? String(parsed.data.date) : undefined,
+    date: normalizeDate(parsed.data.date),
+    lastReviewed: normalizeDate(parsed.data.lastReviewed),
+    status: normalizeStatus(parsed.data.status),
+    platforms: normalizeStringList(parsed.data.platforms),
     tags,
     parentUrl: null,
     section: slug.split("/")[0] ?? "",
@@ -409,6 +449,19 @@ function normalizeStringList(value: unknown) {
   if (!value) return [];
   if (Array.isArray(value)) return value.map(String).filter(Boolean);
   return [String(value)].filter(Boolean);
+}
+
+function normalizeDate(value: unknown) {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value.toISOString().slice(0, 10);
+  }
+  const date = String(value ?? "").trim();
+  return /^\d{4}-\d{2}-\d{2}(?:$|[T\s])/.test(date) ? date.slice(0, 10) : undefined;
+}
+
+function normalizeStatus(value: unknown): KbPage["status"] {
+  const status = String(value ?? "").trim().toLowerCase();
+  return status === "deprecated" || status === "archived" ? status : undefined;
 }
 
 function slugify(value: string) {

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -1,6 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
-import { getPages, renderPage } from "@lib/content";
+import { getPageNeighbors, getPages, getRelatedPages, renderPage } from "@lib/content";
 
 export function getStaticPaths() {
   return getPages()
@@ -13,8 +13,45 @@ export function getStaticPaths() {
 
 const { page } = Astro.props;
 const html = renderPage(page);
+const relatedPages = getRelatedPages(page);
+const neighbors = getPageNeighbors(page);
 ---
 
 <BaseLayout page={page} title={page.title} description={page.description}>
   <article class="content prose" data-pagefind-body set:html={html} />
+  <div class="pagefind-meta" aria-hidden="true">
+    <span data-pagefind-meta="section" data-pagefind-filter="section">{page.section}</span>
+    {page.tags.map((tag) => <span data-pagefind-filter="tag">{tag}</span>)}
+  </div>
+
+  {(neighbors.previous || neighbors.next) && (
+    <nav class="page-nav" aria-label="Page navigation">
+      {neighbors.previous ? (
+        <a href={neighbors.previous.url}>
+          <small>previous</small>
+          {neighbors.previous.title}
+        </a>
+      ) : <span />}
+      {neighbors.next ? (
+        <a class="next" href={neighbors.next.url}>
+          <small>next</small>
+          {neighbors.next.title}
+        </a>
+      ) : <span />}
+    </nav>
+  )}
+
+  {relatedPages.length > 0 && (
+    <section class="related-pages" aria-labelledby="related-pages-title">
+      <h2 id="related-pages-title">Related notes</h2>
+      <div class="related-grid">
+        {relatedPages.map((related) => (
+          <a href={related.url}>
+            {related.title}
+            {related.description && <p>{related.description}</p>}
+          </a>
+        ))}
+      </div>
+    </section>
+  )}
 </BaseLayout>

--- a/src/pages/search.json.ts
+++ b/src/pages/search.json.ts
@@ -7,7 +7,11 @@ export const GET: APIRoute = () => {
     description: page.description,
     url: page.url,
     tags: page.tags,
-    section: page.section
+    section: page.section,
+    date: page.date ?? null,
+    lastReviewed: page.lastReviewed ?? null,
+    status: page.status ?? "active",
+    platforms: page.platforms
   }));
 
   return new Response(JSON.stringify(pages), {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -22,6 +22,35 @@
   box-sizing: border-box;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.skip-link {
+  position: fixed;
+  z-index: 100;
+  top: 8px;
+  left: 8px;
+  padding: 8px 12px;
+  color: var(--bg);
+  background: var(--green);
+  border-radius: 5px;
+  transform: translateY(-150%);
+  transition: transform 120ms ease;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
 html {
   background: var(--bg);
   font-family: var(--sans);
@@ -46,6 +75,15 @@ a {
 button,
 input {
   font: inherit;
+}
+
+button:focus-visible,
+a:focus-visible,
+summary:focus-visible,
+select:focus-visible,
+input:focus-visible {
+  outline: 2px solid var(--green);
+  outline-offset: 3px;
 }
 
 .app-shell {
@@ -384,6 +422,43 @@ h1 {
   line-height: 1.6;
 }
 
+.page-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 18px;
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+.page-meta div {
+  display: flex;
+  gap: 6px;
+}
+
+.page-meta dt {
+  color: var(--dim);
+}
+
+.page-meta dd {
+  margin: 0;
+}
+
+.status-badge {
+  padding: 2px 6px;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+}
+
+.status-deprecated {
+  color: var(--amber);
+}
+
+.status-archived {
+  color: var(--red);
+}
+
 .tag-row {
   margin-top: 18px;
 }
@@ -697,6 +772,36 @@ h1 {
   border-bottom: 1px solid var(--line);
 }
 
+.search-filters {
+  display: flex;
+  gap: 10px;
+  padding: 12px 22px;
+  border-bottom: 1px solid var(--line);
+}
+
+.search-filters label {
+  display: grid;
+  flex: 1;
+  gap: 5px;
+  padding: 0;
+  border: 0;
+}
+
+.search-filters label span {
+  margin: 0;
+  color: var(--dim);
+  font-size: 11px;
+}
+
+.search-filters select {
+  min-width: 0;
+  padding: 6px 8px;
+  color: var(--text);
+  background: var(--panel-strong);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+}
+
 .search-dialog label span {
   display: block;
   margin-bottom: 8px;
@@ -736,6 +841,14 @@ h1 {
   color: var(--text);
 }
 
+.search-results small {
+  display: block;
+  margin-top: 4px;
+  color: var(--cyan);
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
 .search-results p {
   margin: 6px 0 0;
   color: var(--muted);
@@ -754,6 +867,74 @@ h1 {
   color: var(--muted);
   font-family: var(--mono);
   font-size: 13px;
+}
+
+.page-nav,
+.related-pages {
+  margin-top: 38px;
+  padding-top: 24px;
+  border-top: 1px solid var(--line);
+}
+
+.page-nav {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.page-nav a,
+.related-pages a {
+  display: block;
+  padding: 13px 15px;
+  color: var(--text);
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 7px;
+}
+
+.page-nav a:hover,
+.related-pages a:hover {
+  border-color: rgba(53, 242, 154, 0.55);
+}
+
+.page-nav small,
+.related-pages small {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--dim);
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.page-nav .next {
+  text-align: right;
+}
+
+.related-pages h2 {
+  margin: 0 0 14px;
+  color: var(--cyan);
+  font-size: 20px;
+}
+
+.related-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 10px;
+}
+
+.related-pages p {
+  margin: 7px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.pagefind-meta {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
 }
 
 @media (max-width: 940px) {
@@ -804,5 +985,26 @@ h1 {
 
   .crumbs {
     font-size: 11px;
+  }
+
+  .search-filters,
+  .page-nav {
+    grid-template-columns: 1fr;
+    flex-direction: column;
+  }
+
+  .page-nav .next {
+    text-align: left;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
   }
 }

--- a/static/js/kb-app.js
+++ b/static/js/kb-app.js
@@ -5,19 +5,24 @@
   const searchOpeners = document.querySelectorAll("[data-search-open]");
   const searchInput = document.querySelector("[data-search-input]");
   const searchResults = document.querySelector("[data-search-results]");
+  const searchSection = document.querySelector("[data-search-section]");
+  const searchTag = document.querySelector("[data-search-tag]");
   let pagefind = null;
   let searchController = null;
   let searchTimer = null;
   let activeResultIndex = -1;
+  let lastFocusedElement = null;
 
   sidebarToggle?.addEventListener("click", () => {
-    body.classList.toggle("sidebar-open");
+    const isOpen = body.classList.toggle("sidebar-open");
+    sidebarToggle.setAttribute("aria-expanded", String(isOpen));
   });
 
   document.addEventListener("click", (event) => {
     if (!body.classList.contains("sidebar-open")) return;
     if (event.target.closest("#site-sidebar") || event.target.closest("[data-sidebar-toggle]")) return;
     body.classList.remove("sidebar-open");
+    sidebarToggle?.setAttribute("aria-expanded", "false");
   });
 
   document.querySelectorAll("pre").forEach((block) => {
@@ -27,12 +32,20 @@
     const button = document.createElement("button");
     button.className = "copy-code";
     button.type = "button";
+    button.setAttribute("aria-label", "Copy code to clipboard");
     button.textContent = "copy";
     button.addEventListener("click", async () => {
-      await navigator.clipboard.writeText(code.innerText);
-      button.textContent = "copied";
+      try {
+        await navigator.clipboard.writeText(code.innerText);
+        button.textContent = "copied";
+        button.setAttribute("aria-label", "Code copied to clipboard");
+      } catch {
+        button.textContent = "copy failed";
+        button.setAttribute("aria-label", "Copy failed");
+      }
       setTimeout(() => {
         button.textContent = "copy";
+        button.setAttribute("aria-label", "Copy code to clipboard");
       }, 1200);
     });
     block.append(button);
@@ -40,12 +53,25 @@
 
   const openSearch = async () => {
     if (!dialog) return;
+    lastFocusedElement = document.activeElement;
+    const params = new URLSearchParams(window.location.search);
+    if (searchInput && params.has("q")) searchInput.value = params.get("q") ?? "";
+    if (searchSection && params.has("section")) searchSection.value = params.get("section") ?? "";
+    if (searchTag && params.has("tag")) searchTag.value = params.get("tag") ?? "";
     dialog.showModal();
     searchInput?.focus();
     await loadPagefind();
+    const query = searchInput?.value.trim().toLowerCase() ?? "";
+    if (query) runSearch(query);
   };
 
   searchOpeners.forEach((button) => button.addEventListener("click", openSearch));
+
+  dialog?.addEventListener("close", () => {
+    lastFocusedElement?.focus?.();
+    lastFocusedElement = null;
+    activeResultIndex = -1;
+  });
 
   const counters = document.querySelectorAll("[data-count]");
   const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
@@ -118,16 +144,31 @@
   searchInput?.addEventListener("input", () => {
     if (!searchResults) return;
     const query = searchInput.value.trim().toLowerCase();
+    syncSearchUrl();
     clearTimeout(searchTimer);
     activeResultIndex = -1;
 
     if (!query) {
       searchResults.innerHTML = "";
+      searchResults.setAttribute("aria-busy", "false");
       return;
     }
 
     searchTimer = setTimeout(() => runSearch(query), 180);
   });
+
+  [searchSection, searchTag].forEach((filter) => {
+    filter?.addEventListener("change", () => {
+      syncSearchUrl();
+      const query = searchInput?.value.trim().toLowerCase() ?? "";
+      if (query) runSearch(query);
+    });
+  });
+
+  const initialSearchParams = new URLSearchParams(window.location.search);
+  if (initialSearchParams.has("q") || initialSearchParams.has("section") || initialSearchParams.has("tag")) {
+    openSearch();
+  }
 
   searchInput?.addEventListener("keydown", (event) => {
     const resultLinks = [...searchResults.querySelectorAll("a")];
@@ -178,36 +219,58 @@
     searchController?.abort();
     searchController = controller;
 
-    searchResults.innerHTML = '<p class="search-status">searching</p>';
+    searchResults.innerHTML = '<p class="search-status" role="status">searching</p>';
+    searchResults.setAttribute("aria-busy", "true");
 
     try {
       const index = await loadPagefind();
-      const search = await index.search(query);
+      const filters = {};
+      if (searchSection?.value) filters.section = searchSection.value;
+      if (searchTag?.value) filters.tag = searchTag.value;
+      const search = await index.search(query, Object.keys(filters).length ? { filters } : undefined);
       if (controller.signal.aborted) return;
 
       const results = await Promise.all(search.results.slice(0, 12).map((result) => result.data()));
       if (controller.signal.aborted) return;
 
       if (!results.length) {
-        searchResults.innerHTML = '<p class="search-status">no results</p>';
+        searchResults.innerHTML = '<p class="search-status" role="status">no results</p>';
         return;
       }
 
       activeResultIndex = -1;
-      searchResults.innerHTML = `<p class="search-status">${results.length} result${
+      searchResults.innerHTML = `<p class="search-status" role="status">${results.length} result${
         results.length === 1 ? "" : "s"
       }</p>${results
         .map(
           (result) => `<a href="${escapeAttr(result.url)}">
             <strong>${escapeHtml(result.meta?.title || result.url)}</strong>
+            ${result.meta?.section ? `<small>${escapeHtml(result.meta.section)}</small>` : ""}
             <p>${sanitizePagefindExcerpt(result.excerpt || result.url)}</p>
           </a>`
         )
         .join("")}`;
     } catch {
       if (controller.signal.aborted) return;
-      searchResults.innerHTML = '<p class="search-status">search unavailable</p>';
+      searchResults.innerHTML = '<p class="search-status" role="status">search unavailable</p>';
+    } finally {
+      if (!controller.signal.aborted) searchResults.setAttribute("aria-busy", "false");
     }
+  }
+
+  function syncSearchUrl() {
+    const url = new URL(window.location.href);
+    const values = {
+      q: searchInput?.value.trim() ?? "",
+      section: searchSection?.value ?? "",
+      tag: searchTag?.value ?? ""
+    };
+
+    Object.entries(values).forEach(([key, value]) => {
+      if (value) url.searchParams.set(key, value);
+      else url.searchParams.delete(key);
+    });
+    window.history.replaceState({}, "", `${url.pathname}${url.search}${url.hash}`);
   }
 
   function escapeHtml(value) {

--- a/test/frontmatter.test.mjs
+++ b/test/frontmatter.test.mjs
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseFrontmatter } from "../src/lib/frontmatter.mjs";
+
+test("parses YAML frontmatter and preserves Markdown content", () => {
+  const result = parseFrontmatter(
+    "---\ntitle: Example\ntags: [one, two]\n---\n\n# Heading\n"
+  );
+
+  assert.deepEqual(result.data, { title: "Example", tags: ["one", "two"] });
+  assert.equal(result.content, "# Heading\n");
+});
+
+test("accepts a UTF-8 BOM before frontmatter", () => {
+  const result = parseFrontmatter("\uFEFF---\ntitle: BOM-safe\n---\nBody");
+
+  assert.equal(result.data.title, "BOM-safe");
+  assert.equal(result.content, "Body");
+});
+
+test("returns content unchanged when frontmatter is absent", () => {
+  const result = parseFrontmatter("# Plain Markdown\n");
+
+  assert.deepEqual(result.data, {});
+  assert.equal(result.content, "# Plain Markdown\n");
+});
+
+test("rejects malformed or non-object frontmatter", () => {
+  assert.throws(
+    () => parseFrontmatter("---\ntitle: Missing closing\n"),
+    /missing closing frontmatter delimiter/
+  );
+  assert.throws(
+    () => parseFrontmatter("---\n- list\n---\nBody"),
+    /frontmatter must be a YAML object/
+  );
+});


### PR DESCRIPTION
## What changed

- Added weighted Pagefind search filters for sections and popular tags.
- Made search state shareable through URL query parameters.
- Added popular tag ranking, related notes, and previous/next navigation.
- Added optional freshness, status, and platform metadata with social sharing tags.
- Improved keyboard and screen-reader support with skip navigation, focus restoration, live search status, button labels, and reduced-motion handling.
- Added parser tests, an environment doctor, CI test/doctor steps, and a scheduled external-link health report.

## Why

The knowledge base had strong content coverage but limited findability and freshness signaling. Search was unfiltered, tags were alphabetical, and several interactive elements lacked complete accessibility state. External links were inventoried but not periodically checked.

## Validation

- `npm run validate`
- 4 unit tests passed
- Astro checks passed with 0 errors, warnings, or hints
- Production build passed: 820 pages
- Pagefind indexed 751 notes with section/tag filters
- Content, link, asset, smoke, dependency audit, and environment checks passed
- Local preview returned HTTP 200 for the homepage, search assets, and query URLs
