### PR TITLE
Add content freshness review queue

### DIFF
--- a/.github/workflows/content-review.yml
+++ b/.github/workflows/content-review.yml
@@ -1,0 +1,41 @@
+name: Content freshness review
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 7 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone this repo
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate content review queue
+        run: |
+          npm run content:review -- \
+            --output .reports/content-review.md \
+            --json .reports/content-review.json \
+            --summary-file "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload content review reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: content-review-queue
+          path: .reports/content-review.*
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/content-review.yml
+++ b/.github/workflows/content-review.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Upload content review reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: content-review-queue
           path: .reports/content-review.*

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Lint content Markdown
         uses: rvben/rumdl@v0
         with:
-          version: '0.2.22'
+          version: '0.2.48'
           path: 'content/'
           config: '.markdownlint.yml'
           report-type: annotations
@@ -37,7 +37,7 @@ jobs:
       - name: Lint README
         uses: rvben/rumdl@v0
         with:
-          version: '0.2.22'
+          version: '0.2.48'
           path: 'README.md'
           config: '.markdownlint.yml'
           report-type: annotations

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ npm run check:content
 npm run check:links
 npm run audit:known
 npm run sysinternals:check
+npm run content:review
 npm test
 npm run doctor
 npm run build
@@ -48,6 +49,14 @@ checks the Node.js version, required project paths, and local npm availability.
 
 The scheduled `Check external links` workflow creates a report of reachable
 external URLs without blocking content builds.
+
+`npm run content:review` scans all publishable pages and writes a maintainer-only
+review queue to `.reports/content-review.md` plus a complete JSON report at
+`.reports/content-review.json`. It always reports missing `lastReviewed` values,
+marks pages stale when their effective review date is more than 12 months old,
+and never changes frontmatter or fails a content build. The scheduled `Content
+freshness review` workflow uploads the same reports weekly and adds a summary to
+the workflow run.
 
 Content pages may optionally define `lastReviewed` (`YYYY-MM-DD`), `status`
 (`active`, `deprecated`, or `archived`), and `platforms` (a string or list of

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "check:outdated": "node scripts/check-outdated.mjs",
     "audit:known": "node scripts/check-audit.mjs",
     "doctor": "node scripts/doctor.mjs",
+    "content:review": "node scripts/content-review.mjs",
     "test": "node --test test/*.test.mjs",
     "sysinternals:check": "node scripts/sync-sysinternals.mjs --check",
     "sysinternals:sync": "node scripts/sync-sysinternals.mjs --write",

--- a/scripts/check-content.mjs
+++ b/scripts/check-content.mjs
@@ -1,6 +1,7 @@
 import { readdir, readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import { parseFrontmatter } from "../src/lib/frontmatter.mjs";
+import { isValidDateValue } from "../src/lib/date.mjs";
 
 const root = process.cwd();
 const contentDir = path.join(root, "content");
@@ -136,9 +137,9 @@ function validatePages() {
     for (const field of ["date", "lastReviewed"]) {
       if (
         page.frontmatter[field] !== undefined &&
-        !isDateValue(page.frontmatter[field])
+        !isValidDateValue(page.frontmatter[field])
       ) {
-        errors.push(`${page.relativeFile}: ${field} must use YYYY-MM-DD`);
+        errors.push(`${page.relativeFile}: ${field} must start with a valid YYYY-MM-DD date`);
       }
     }
 
@@ -163,11 +164,6 @@ function validatePages() {
       errors.push(`duplicate URL ${url}: ${files.join(", ")}`);
     }
   }
-}
-
-function isDateValue(value) {
-  if (value instanceof Date) return !Number.isNaN(value.getTime());
-  return /^\d{4}-\d{2}-\d{2}(?:$|[T\s])/.test(String(value).trim());
 }
 
 function validateRefsAndShortcodes() {

--- a/scripts/content-review.mjs
+++ b/scripts/content-review.mjs
@@ -1,0 +1,321 @@
+import { appendFile, mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { parseFrontmatter } from "../src/lib/frontmatter.mjs";
+import {
+  differenceInDays,
+  normalizeDate,
+  subtractMonths
+} from "../src/lib/date.mjs";
+
+export const DEFAULT_OUTPUT = ".reports/content-review.md";
+export const DEFAULT_JSON_OUTPUT = ".reports/content-review.json";
+export const DEFAULT_STALE_MONTHS = 12;
+export const DEFAULT_LIMIT = 100;
+
+const contentRoot = path.join(process.cwd(), "content");
+const collator = new Intl.Collator("en", { sensitivity: "base", numeric: true });
+
+export async function collectContentPages(directory = contentRoot) {
+  const files = [];
+  await walkMarkdown(directory, files);
+
+  const pages = [];
+  for (const file of files.sort((a, b) => collator.compare(a, b))) {
+    const raw = await readFile(file, "utf8");
+    const relativeFile = slash(path.relative(directory, file));
+    const parsed = parseFrontmatter(raw, relativeFile);
+    if (parsed.data.draft === true) continue;
+
+    const slug = slugFromFile(relativeFile);
+    pages.push({
+      relativeFile,
+      url: slug ? `/${slug}/` : "/",
+      title: String(parsed.data.title ?? "").trim() || titleFromSlug(slug || "Knowledge Base"),
+      section: slug.split("/")[0] || "index",
+      date: normalizeDate(parsed.data.date),
+      lastReviewed: normalizeDate(parsed.data.lastReviewed)
+    });
+  }
+
+  return pages;
+}
+
+export function classifyReviewPage(page, { asOf, staleBefore }) {
+  const normalizedAsOf = normalizeDate(asOf);
+  const normalizedStaleBefore = normalizeDate(staleBefore);
+  if (!normalizedAsOf || !normalizedStaleBefore) {
+    throw new Error("Review dates must use valid YYYY-MM-DD values");
+  }
+
+  const effectiveDate = page.lastReviewed ?? page.date ?? null;
+  const missingReview = !page.lastReviewed;
+  const stale = Boolean(effectiveDate && effectiveDate < normalizedStaleBefore);
+  const futureDate = Boolean(effectiveDate && effectiveDate > normalizedAsOf);
+  const reasons = [];
+
+  if (missingReview) reasons.push("missing-lastReviewed");
+  if (stale) reasons.push("stale");
+  if (futureDate) reasons.push("future-date");
+
+  return {
+    ...page,
+    date: page.date ?? null,
+    lastReviewed: page.lastReviewed ?? null,
+    effectiveDate,
+    ageDays: effectiveDate ? differenceInDays(normalizedAsOf, effectiveDate) : null,
+    missingReview,
+    stale,
+    futureDate,
+    needsReview: missingReview || stale,
+    reasons
+  };
+}
+
+export function createReviewReport(pages, options = {}) {
+  const asOf = normalizeDate(options.asOf ?? currentUtcDate());
+  const staleMonths = options.staleMonths ?? DEFAULT_STALE_MONTHS;
+  const limit = options.limit ?? DEFAULT_LIMIT;
+
+  if (!asOf) throw new Error("--as-of must use a valid YYYY-MM-DD date");
+  if (!Number.isInteger(staleMonths) || staleMonths < 1) {
+    throw new Error("stale months must be a positive integer");
+  }
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new Error("report limit must be a positive integer");
+  }
+
+  const staleBefore = subtractMonths(asOf, staleMonths);
+  const reviewedPages = pages.map((page) =>
+    classifyReviewPage(page, { asOf, staleBefore })
+  );
+  reviewedPages.sort(compareReviewPages);
+
+  const needsReview = reviewedPages.filter((page) => page.needsReview);
+  const futureDates = reviewedPages.filter((page) => page.futureDate);
+  const current = reviewedPages.filter((page) => !page.needsReview && !page.futureDate);
+
+  return {
+    asOf,
+    staleAfterMonths: staleMonths,
+    staleBefore,
+    limit,
+    summary: {
+      totalPages: reviewedPages.length,
+      needsReview: needsReview.length,
+      missingLastReviewed: reviewedPages.filter((page) => page.missingReview).length,
+      stale: reviewedPages.filter((page) => page.stale).length,
+      futureDates: futureDates.length,
+      reviewed: reviewedPages.filter((page) => page.lastReviewed).length,
+      current: current.length
+    },
+    pages: reviewedPages
+  };
+}
+
+export function compareReviewPages(a, b) {
+  const priority = (page) => {
+    if (page.futureDate) return 0;
+    if (page.stale) return 1;
+    if (page.missingReview) return 2;
+    return 3;
+  };
+
+  return (
+    priority(a) - priority(b) ||
+    (a.effectiveDate ?? "9999-12-31").localeCompare(b.effectiveDate ?? "9999-12-31") ||
+    collator.compare(a.title, b.title) ||
+    collator.compare(a.url, b.url)
+  );
+}
+
+export function renderMarkdown(report) {
+  const queue = report.pages.filter((page) => page.needsReview);
+  const visible = queue.slice(0, report.limit);
+  const lines = [
+    "# Content review queue",
+    "",
+    `As of **${report.asOf}**. A page is stale when its effective review date is before **${report.staleBefore}** (${report.staleAfterMonths} months).`,
+    "",
+    `- Pages scanned: ${report.summary.totalPages}`,
+    `- Pages requiring review: ${report.summary.needsReview}`,
+    "- Missing `lastReviewed`: " + report.summary.missingLastReviewed,
+    `- Stale: ${report.summary.stale}`,
+    `- Future dates: ${report.summary.futureDates}`,
+    `- Reviewed pages: ${report.summary.reviewed}`,
+    ""
+  ];
+
+  if (!visible.length) {
+    lines.push("No pages currently require review.", "");
+    if (report.summary.futureDates) {
+      lines.push(
+        `The JSON report contains ${report.summary.futureDates} future-date data issue(s).`,
+        ""
+      );
+    }
+    return `${lines.join("\n")}\n`;
+  }
+
+  lines.push(
+    `Showing the oldest ${visible.length} queue entries. The JSON report contains all ${queue.length} queue entries and any future-date data issues.`,
+    "",
+    "| # | Page | Section | Effective date | Last reviewed | Age (days) | Reason |",
+    "| ---: | --- | --- | --- | --- | ---: | --- |"
+  );
+
+  visible.forEach((page, index) => {
+    lines.push(
+      `| ${index + 1} | [${escapeTable(page.title)}](${page.url}) | ${escapeTable(
+        page.section
+      )} | ${page.effectiveDate ?? "—"} | ${page.lastReviewed ?? "—"} | ${
+        page.ageDays ?? "—"
+      } | ${escapeTable(page.reasons.join(", "))} |`
+    );
+  });
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function renderSummary(report) {
+  return [
+    "## Content review queue",
+    `- As of: ${report.asOf}`,
+    `- Pages scanned: ${report.summary.totalPages}`,
+    `- Pages requiring review: ${report.summary.needsReview}`,
+    `- Missing lastReviewed: ${report.summary.missingLastReviewed}`,
+    `- Stale: ${report.summary.stale}`,
+    `- Future dates: ${report.summary.futureDates}`
+  ].join("\n");
+}
+
+export async function run(argv = process.argv.slice(2)) {
+  const options = parseArguments(argv);
+  const pages = await collectContentPages();
+  const report = createReviewReport(pages, options);
+  const markdown = renderMarkdown(report);
+  const json = `${JSON.stringify(report, null, 2)}\n`;
+
+  await writeOutput(options.output, markdown);
+  await writeOutput(options.json, json);
+  if (options.summaryFile) {
+    await appendFile(options.summaryFile, `${renderSummary(report)}\n`);
+  }
+
+  console.log(
+    `Content review: ${report.summary.totalPages} pages scanned; ${report.summary.needsReview} requiring review; ${report.summary.futureDates} future-date issue(s)`
+  );
+  return report;
+}
+
+export function parseArguments(argv = []) {
+  const options = {
+    output: path.resolve(process.cwd(), DEFAULT_OUTPUT),
+    json: path.resolve(process.cwd(), DEFAULT_JSON_OUTPUT),
+    summaryFile: undefined,
+    asOf: currentUtcDate(),
+    staleMonths: DEFAULT_STALE_MONTHS,
+    limit: DEFAULT_LIMIT
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    const [flag, inlineValue] = argument.split("=", 2);
+    const value = inlineValue ?? argv[++index];
+
+    switch (flag) {
+      case "--output":
+        options.output = path.resolve(process.cwd(), requireValue(flag, value));
+        break;
+      case "--json":
+        options.json = path.resolve(process.cwd(), requireValue(flag, value));
+        break;
+      case "--summary-file":
+        options.summaryFile = path.resolve(process.cwd(), requireValue(flag, value));
+        break;
+      case "--as-of":
+        options.asOf = requireValue(flag, value);
+        break;
+      case "--stale-months":
+        options.staleMonths = parsePositiveInteger(flag, value);
+        break;
+      case "--limit":
+        options.limit = parsePositiveInteger(flag, value);
+        break;
+      default:
+        throw new Error(`Unknown option ${flag}`);
+    }
+  }
+
+  return options;
+}
+
+async function walkMarkdown(directory, files) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  for (const entry of entries) {
+    const absolute = path.join(directory, entry.name);
+    if (entry.isDirectory()) await walkMarkdown(absolute, files);
+    else if (entry.name.endsWith(".md")) files.push(absolute);
+  }
+}
+
+async function writeOutput(file, content) {
+  await mkdir(path.dirname(file), { recursive: true });
+  await writeFile(file, content);
+}
+
+function requireValue(flag, value) {
+  if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value`);
+  return value;
+}
+
+function parsePositiveInteger(flag, value) {
+  const parsed = Number(requireValue(flag, value));
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${flag} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function currentUtcDate() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function escapeTable(value) {
+  return String(value).replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
+function slugFromFile(relativeFile) {
+  if (relativeFile === "_index.md") return "";
+  return relativeFile
+    .replace(/\/index\.md$/i, "")
+    .replace(/\/_index\.md$/i, "")
+    .replace(/\.md$/i, "")
+    .replace(/^_index$/i, "");
+}
+
+function titleFromSlug(slug) {
+  return slug
+    .split("/")
+    .filter(Boolean)
+    .pop()
+    ?.replace(/[-_]+/g, " ")
+    .replace(/\b\w/g, (character) => character.toUpperCase()) ?? "Knowledge Base";
+}
+
+function slash(value) {
+  return value.replace(/\\/g, "/");
+}
+
+const isMain =
+  process.argv[1] &&
+  pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+
+if (isMain) {
+  try {
+    await run();
+  } catch (error) {
+    console.error(`error: ${error.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import MarkdownIt from "markdown-it";
 import anchor from "markdown-it-anchor";
 import { parseFrontmatter } from "./frontmatter.mjs";
+import { normalizeDate } from "./date.mjs";
 
 const root = process.cwd();
 const contentRoot = path.join(root, "content");
@@ -449,14 +450,6 @@ function normalizeStringList(value: unknown) {
   if (!value) return [];
   if (Array.isArray(value)) return value.map(String).filter(Boolean);
   return [String(value)].filter(Boolean);
-}
-
-function normalizeDate(value: unknown) {
-  if (value instanceof Date && !Number.isNaN(value.getTime())) {
-    return value.toISOString().slice(0, 10);
-  }
-  const date = String(value ?? "").trim();
-  return /^\d{4}-\d{2}-\d{2}(?:$|[T\s])/.test(date) ? date.slice(0, 10) : undefined;
 }
 
 function normalizeStatus(value: unknown): KbPage["status"] {

--- a/src/lib/date.mjs
+++ b/src/lib/date.mjs
@@ -1,0 +1,70 @@
+const datePattern = /^(\d{4})-(\d{2})-(\d{2})(?:$|[T\s])/;
+const millisecondsPerDay = 24 * 60 * 60 * 1000;
+
+export function normalizeDate(value) {
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) return undefined;
+    return value.toISOString().slice(0, 10);
+  }
+
+  const text = String(value ?? "").trim();
+  const match = text.match(datePattern);
+  if (!match) return undefined;
+
+  const normalized = `${match[1]}-${match[2]}-${match[3]}`;
+  return isValidCalendarDate(normalized) ? normalized : undefined;
+}
+
+export function isValidDateValue(value) {
+  return Boolean(normalizeDate(value));
+}
+
+export function parseDateOnly(value) {
+  const normalized = normalizeDate(value);
+  if (!normalized) return undefined;
+
+  const [year, month, day] = normalized.split("-").map(Number);
+  const date = new Date(0);
+  date.setUTCHours(0, 0, 0, 0);
+  date.setUTCFullYear(year, month - 1, day);
+  return date;
+}
+
+export function subtractMonths(value, months) {
+  const normalized = normalizeDate(value);
+  if (!normalized || !Number.isInteger(months) || months < 0) return undefined;
+
+  const [year, month, day] = normalized.split("-").map(Number);
+  const monthIndex = year * 12 + month - 1 - months;
+  const targetYear = Math.floor(monthIndex / 12);
+  const targetMonth = monthIndex % 12;
+  const targetDay = Math.min(day, daysInMonth(targetYear, targetMonth + 1));
+
+  return formatDate(targetYear, targetMonth + 1, targetDay);
+}
+
+export function differenceInDays(later, earlier) {
+  const laterDate = parseDateOnly(later);
+  const earlierDate = parseDateOnly(earlier);
+  if (!laterDate || !earlierDate) return undefined;
+  return Math.floor((laterDate.getTime() - earlierDate.getTime()) / millisecondsPerDay);
+}
+
+function isValidCalendarDate(value) {
+  const [year, month, day] = value.split("-").map(Number);
+  return month >= 1 && month <= 12 && day >= 1 && day <= daysInMonth(year, month);
+}
+
+function daysInMonth(year, month) {
+  if (month === 2) {
+    const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+    return leap ? 29 : 28;
+  }
+  return [4, 6, 9, 11].includes(month) ? 30 : 31;
+}
+
+function formatDate(year, month, day) {
+  return [year, month, day]
+    .map((value, index) => (index === 0 ? String(value).padStart(4, "0") : String(value).padStart(2, "0")))
+    .join("-");
+}

--- a/test/content-review.test.mjs
+++ b/test/content-review.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  collectContentPages,
+  createReviewReport,
+  classifyReviewPage,
+  renderMarkdown
+} from "../scripts/content-review.mjs";
+import {
+  differenceInDays,
+  isValidDateValue,
+  normalizeDate,
+  subtractMonths
+} from "../src/lib/date.mjs";
+
+const asOf = "2026-08-02";
+const staleBefore = "2025-08-02";
+
+test("normalizes timestamp dates and rejects impossible calendar dates", () => {
+  assert.equal(normalizeDate("2021-02-08T09:52:22+01:00"), "2021-02-08");
+  assert.equal(normalizeDate("2024-02-29"), "2024-02-29");
+  assert.equal(normalizeDate("2024-02-30"), undefined);
+  assert.equal(normalizeDate("2023-02-29"), undefined);
+  assert.equal(isValidDateValue("2024-04-31T00:00:00Z"), false);
+  assert.equal(isValidDateValue("2024-04-30T00:00:00Z"), true);
+});
+
+test("subtracts calendar months with leap-day clamping", () => {
+  assert.equal(subtractMonths(asOf, 12), staleBefore);
+  assert.equal(subtractMonths("2024-02-29", 12), "2023-02-28");
+});
+
+test("keeps the 12-month boundary current and marks older dates stale", () => {
+  const boundary = classifyReviewPage(
+    { title: "Boundary", url: "/boundary/", section: "test", date: null, lastReviewed: staleBefore },
+    { asOf, staleBefore }
+  );
+  const older = classifyReviewPage(
+    { title: "Older", url: "/older/", section: "test", date: null, lastReviewed: "2025-08-01" },
+    { asOf, staleBefore }
+  );
+
+  assert.equal(boundary.stale, false);
+  assert.equal(boundary.needsReview, false);
+  assert.equal(older.stale, true);
+  assert.equal(older.needsReview, true);
+  assert.equal(differenceInDays(asOf, "2025-08-01"), 366);
+});
+
+test("reports missing reviews, future dates, and effective-date age", () => {
+  const missing = classifyReviewPage(
+    { title: "Missing", url: "/missing/", section: "test", date: "2020-01-01", lastReviewed: null },
+    { asOf, staleBefore }
+  );
+  const future = classifyReviewPage(
+    { title: "Future", url: "/future/", section: "test", date: null, lastReviewed: "2026-08-03" },
+    { asOf, staleBefore }
+  );
+
+  assert.deepEqual(missing.reasons, ["missing-lastReviewed", "stale"]);
+  assert.equal(missing.needsReview, true);
+  assert.equal(missing.ageDays, 2405);
+  assert.deepEqual(future.reasons, ["future-date"]);
+  assert.equal(future.futureDate, true);
+  assert.equal(future.stale, false);
+  assert.equal(future.needsReview, false);
+});
+
+test("sorts same-date entries deterministically and limits Markdown output", () => {
+  const report = createReviewReport(
+    [
+      { title: "Zulu", url: "/zulu/", section: "test", date: "2025-08-02", lastReviewed: null },
+      { title: "Alpha", url: "/alpha/", section: "test", date: "2025-08-02", lastReviewed: null }
+    ],
+    { asOf, limit: 1 }
+  );
+
+  assert.deepEqual(report.pages.map((page) => page.title), ["Alpha", "Zulu"]);
+  const markdown = renderMarkdown(report);
+  assert.match(markdown, /Showing the oldest 1 queue entries/);
+  assert.match(markdown, /\[Alpha\]\(\/alpha\/\)/);
+  assert.doesNotMatch(markdown, /\[Zulu\]\(\/zulu\/\)/);
+});
+
+test("indexes the full publishable content corpus", async () => {
+  const pages = await collectContentPages();
+  const report = createReviewReport(pages, { asOf });
+
+  assert.ok(pages.length >= 751);
+  assert.equal(report.pages.length, pages.length);
+  assert.equal(
+    report.summary.needsReview,
+    report.pages.filter((page) => page.needsReview).length
+  );
+  assert.equal(
+    report.summary.missingLastReviewed,
+    report.pages.filter((page) => page.missingReview).length
+  );
+  assert.equal(report.summary.totalPages, report.pages.length);
+});


### PR DESCRIPTION
## What changed

- Added `npm run content:review` to classify all publishable pages by freshness.
- Added deterministic Markdown and complete JSON reports under `.reports/`.
- Added strict calendar-date validation while preserving existing timestamp-style dates.
- Added a weekly/manual GitHub Actions workflow with artifacts and a job summary.
- Added unit and full-corpus tests plus README documentation.

## Why

The freshness metadata is available but no existing page currently has `lastReviewed`. This adds a maintainer-only, report-only review queue without inventing or mass-editing frontmatter.

## Validation

- `npm test` — 10 tests passed
- `npm run check:content`
- `npm run check`
- `npm run validate`
- Full corpus: 751 pages represented in JSON
- Production build: 820 pages; Pagefind indexed 751 pages
- Asset, link, smoke, and dependency audit checks passed
