### PR TITLE
Add inherited content metadata normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ Content pages may optionally define `lastReviewed` (`YYYY-MM-DD`), `status`
 strings). These fields power freshness and compatibility hints without being
 required for existing pages.
 
+Section `_index.md` files may also define a `cascade` mapping. Its metadata is
+inherited by descendant pages unless a closer section or the page itself
+provides an explicit value. This preserves the existing Hugo-style taxonomy
+without rewriting content frontmatter. The content checker validates cascade
+values, including the legacy `tags= [...]` form, and the site normalizes known
+tag aliases such as `Wirehark` to `Wireshark`.
+
 Use `npm run sysinternals:check` to compare the published Sysinternals files
 with `https://live.sysinternals.com/`. Use `npm run sysinternals:sync` to
 download missing or changed root and ARM64 files. The sync workflow skips live

--- a/scripts/check-content.mjs
+++ b/scripts/check-content.mjs
@@ -2,6 +2,7 @@ import { readdir, readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import { parseFrontmatter } from "../src/lib/frontmatter.mjs";
 import { isValidDateValue } from "../src/lib/date.mjs";
+import { parseCascade } from "../src/lib/metadata.mjs";
 
 const root = process.cwd();
 const contentDir = path.join(root, "content");
@@ -157,12 +158,51 @@ function validatePages() {
         (Array.isArray(platforms) && platforms.every((platform) => typeof platform === "string"));
       if (!valid) errors.push(`${page.relativeFile}: platforms must be a string or string array`);
     }
+
+    if (page.frontmatter.cascade !== undefined) {
+      try {
+        const cascade = parseCascade(page.frontmatter.cascade, page.relativeFile);
+        validateCascadeFields(cascade, page.relativeFile);
+      } catch (error) {
+        errors.push(error.message);
+      }
+    }
   }
 
   for (const [url, files] of urls) {
     if (files.length > 1) {
       errors.push(`duplicate URL ${url}: ${files.join(", ")}`);
     }
+  }
+}
+
+function validateCascadeFields(cascade, file) {
+  if (cascade.tags !== undefined) {
+    const valid =
+      typeof cascade.tags === "string" ||
+      (Array.isArray(cascade.tags) && cascade.tags.every((tag) => typeof tag === "string"));
+    if (!valid) errors.push(`${file}: cascade.tags must be a string or string array`);
+  }
+
+  if (cascade.platforms !== undefined) {
+    const valid =
+      typeof cascade.platforms === "string" ||
+      (Array.isArray(cascade.platforms) &&
+        cascade.platforms.every((platform) => typeof platform === "string"));
+    if (!valid) errors.push(`${file}: cascade.platforms must be a string or string array`);
+  }
+
+  for (const field of ["date", "lastReviewed"]) {
+    if (cascade[field] !== undefined && !isValidDateValue(cascade[field])) {
+      errors.push(`${file}: cascade.${field} must start with a valid YYYY-MM-DD date`);
+    }
+  }
+
+  if (
+    cascade.status !== undefined &&
+    !pageStatuses.has(String(cascade.status).trim().toLowerCase())
+  ) {
+    errors.push(`${file}: cascade.status must be active, deprecated, or archived`);
   }
 }
 

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -4,6 +4,12 @@ import MarkdownIt from "markdown-it";
 import anchor from "markdown-it-anchor";
 import { parseFrontmatter } from "./frontmatter.mjs";
 import { normalizeDate } from "./date.mjs";
+import {
+  canonicalTag,
+  resolveInheritedFrontmatter,
+  tagKey,
+  uniqueStrings
+} from "./metadata.mjs";
 
 const root = process.cwd();
 const contentRoot = path.join(root, "content");
@@ -60,10 +66,22 @@ export function getPages() {
   if (cache) return cache;
 
   const files = listMarkdown(contentRoot);
-  const pages = files.map(parsePage).filter((page) => page.frontmatter.draft !== true);
+  const allPages = files.map(parsePage);
+  const allByUrl = new Map(allPages.map((page) => [page.url, page]));
+
+  for (const page of allPages) {
+    page.parentUrl = findParentUrl(page.url, allByUrl);
+  }
+
+  for (const page of allPages) {
+    hydratePage(page, resolveInheritedFrontmatter(page, allByUrl));
+  }
+
+  const pages = allPages.filter((page) => page.frontmatter.draft !== true);
   const byUrl = new Map(pages.map((page) => [page.url, page]));
 
   for (const page of pages) {
+    page.children = [];
     page.parentUrl = findParentUrl(page.url, byUrl);
     if (page.parentUrl) {
       byUrl.get(page.parentUrl)?.children.push(page);
@@ -99,8 +117,8 @@ export function getAllTags() {
   const tags = new Map<string, { tag: string; count: number }>();
   for (const page of getPages()) {
     for (const tag of page.tags) {
-      const key = tagSlug(tag);
-      const current = tags.get(key) ?? { tag, count: 0 };
+      const key = tagKey(tag);
+      const current = tags.get(key) ?? { tag: canonicalTag(tag), count: 0 };
       current.count += 1;
       tags.set(key, current);
     }
@@ -159,7 +177,7 @@ export function renderInlineMarkdown(source: string) {
 }
 
 export function tagSlug(tag: string) {
-  return slugify(tag);
+  return tagKey(tag);
 }
 
 export function sortPages(a: KbPage, b: KbPage) {
@@ -173,8 +191,6 @@ function parsePage(file: string): KbPage {
   const parsed = parseFrontmatter(raw, relativeFile);
   const slug = slugFromFile(relativeFile);
   const url = slug ? `/${slug}/` : "/";
-  const title = normalizeTitle(parsed.data.title) || titleFromSlug(slug || "Knowledge Base");
-  const tags = normalizeStringList(parsed.data.tags);
 
   return {
     file,
@@ -182,21 +198,35 @@ function parsePage(file: string): KbPage {
     sourceDir: slash(path.dirname(relativeFile)),
     slug,
     url,
-    title,
-    description: String(parsed.data.description ?? ""),
+    title: "",
+    description: "",
     body: parsed.content.trim(),
     frontmatter: parsed.data,
-    weight: Number(parsed.data.weight ?? Number.MAX_SAFE_INTEGER),
-    date: normalizeDate(parsed.data.date),
-    lastReviewed: normalizeDate(parsed.data.lastReviewed),
-    status: normalizeStatus(parsed.data.status),
-    platforms: normalizeStringList(parsed.data.platforms),
-    tags,
+    weight: Number.MAX_SAFE_INTEGER,
+    date: undefined,
+    lastReviewed: undefined,
+    status: undefined,
+    platforms: [],
+    tags: [],
     parentUrl: null,
     section: slug.split("/")[0] ?? "",
     children: [],
     breadcrumbs: []
   };
+}
+
+function hydratePage(page: KbPage, frontmatter: Record<string, any>) {
+  const title = normalizeTitle(frontmatter.title) || titleFromSlug(page.slug || "Knowledge Base");
+
+  page.frontmatter = frontmatter;
+  page.title = title;
+  page.description = String(frontmatter.description ?? "");
+  page.weight = Number(frontmatter.weight ?? Number.MAX_SAFE_INTEGER);
+  page.date = normalizeDate(frontmatter.date);
+  page.lastReviewed = normalizeDate(frontmatter.lastReviewed);
+  page.status = normalizeStatus(frontmatter.status);
+  page.platforms = uniqueStrings(frontmatter.platforms);
+  page.tags = [...new Set(uniqueStrings(frontmatter.tags).map(canonicalTag))];
 }
 
 function preprocessShortcodes(source: string, page: KbPage) {
@@ -444,12 +474,6 @@ function titleFromSlug(slug: string) {
 
 function normalizeTitle(value: unknown) {
   return String(value ?? "").trim();
-}
-
-function normalizeStringList(value: unknown) {
-  if (!value) return [];
-  if (Array.isArray(value)) return value.map(String).filter(Boolean);
-  return [String(value)].filter(Boolean);
 }
 
 function normalizeStatus(value: unknown): KbPage["status"] {

--- a/src/lib/metadata.mjs
+++ b/src/lib/metadata.mjs
@@ -1,0 +1,104 @@
+import { parseFrontmatter } from "./frontmatter.mjs";
+
+const tagAliases = new Map([
+  ["hash-cracking", "Hash Cracking"],
+  ["wirehark", "Wireshark"]
+]);
+
+export function parseCascade(value, file = "content") {
+  if (value === undefined || value === null) return {};
+
+  if (isPlainObject(value)) {
+    if (Object.hasOwn(value, "cascade")) {
+      throw new Error(`${file}: cascade cannot contain another cascade`);
+    }
+    return { ...value };
+  }
+
+  if (typeof value === "string") {
+    const legacy = value.trim().match(/^([A-Za-z][A-Za-z0-9_-]*)\s*=\s*([\s\S]+)$/);
+    if (!legacy) {
+      throw new Error(`${file}: cascade must be a YAML object`);
+    }
+
+    try {
+      return parseFrontmatter(
+        `---\n${legacy[1]}: ${legacy[2]}\n---\n`,
+        `${file} cascade`
+      ).data;
+    } catch (error) {
+      throw new Error(`${file}: invalid cascade value: ${error.message}`);
+    }
+  }
+
+  throw new Error(`${file}: cascade must be a YAML object`);
+}
+
+export function resolveInheritedFrontmatter(page, byUrl) {
+  const ancestors = [];
+  const visited = new Set();
+  let current = page.parentUrl ? byUrl.get(page.parentUrl) : undefined;
+
+  while (current) {
+    if (visited.has(current.url)) {
+      throw new Error(`metadata inheritance cycle detected at ${current.url}`);
+    }
+    visited.add(current.url);
+    ancestors.unshift(current);
+    current = current.parentUrl ? byUrl.get(current.parentUrl) : undefined;
+  }
+
+  const inherited = {};
+  for (const ancestor of ancestors) {
+    Object.assign(
+      inherited,
+      parseCascade(ancestor.frontmatter.cascade, ancestor.relativeFile)
+    );
+  }
+
+  return normalizeFrontmatter({ ...inherited, ...page.frontmatter });
+}
+
+export function normalizeFrontmatter(frontmatter) {
+  const normalized = { ...frontmatter };
+
+  if (normalized.tags !== undefined) {
+    normalized.tags = [...new Set(uniqueStrings(normalized.tags).map(canonicalTag))];
+  }
+  if (normalized.platforms !== undefined) {
+    normalized.platforms = uniqueStrings(normalized.platforms);
+  }
+  if (normalized.status !== undefined) {
+    normalized.status = String(normalized.status).trim().toLowerCase();
+  }
+
+  return normalized;
+}
+
+export function canonicalTag(value) {
+  const label = String(value ?? "").trim();
+  return tagAliases.get(tagKey(label)) ?? label;
+}
+
+export function tagKey(value) {
+  return slugify(String(value ?? ""));
+}
+
+export function uniqueStrings(value) {
+  if (!value) return [];
+  const values = Array.isArray(value) ? value : [value];
+  return [...new Set(values.map((item) => String(item).trim()).filter(Boolean))];
+}
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[\u0027\u0060\"]+/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/test/metadata.test.mjs
+++ b/test/metadata.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  canonicalTag,
+  parseCascade,
+  resolveInheritedFrontmatter,
+  tagKey,
+  uniqueStrings
+} from "../src/lib/metadata.mjs";
+
+test("parses object and legacy assignment cascade values", () => {
+  assert.deepEqual(parseCascade({ tags: ["Tools"] }, "section/_index.md"), {
+    tags: ["Tools"]
+  });
+  assert.deepEqual(parseCascade("tags= ['macOS']", "commands/macos/_index.md"), {
+    tags: ["macOS"]
+  });
+  assert.throws(
+    () => parseCascade("not a cascade", "broken/_index.md"),
+    /cascade must be a YAML object/
+  );
+});
+
+test("inherits the nearest cascade while preserving explicit child metadata", () => {
+  const root = {
+    url: "/",
+    parentUrl: null,
+    relativeFile: "_index.md",
+    frontmatter: { cascade: { tags: ["Tools"], platforms: ["Linux"] } }
+  };
+  const section = {
+    url: "/tools/",
+    parentUrl: "/",
+    relativeFile: "tools/_index.md",
+    frontmatter: { cascade: { tags: ["Networking"] } }
+  };
+  const inherited = {
+    url: "/tools/nmap/",
+    parentUrl: "/tools/",
+    relativeFile: "tools/nmap/index.md",
+    frontmatter: { title: "Nmap" }
+  };
+  const explicit = {
+    ...inherited,
+    frontmatter: { title: "Nmap", tags: ["Wirehark"] }
+  };
+  const byUrl = new Map([root, section, inherited, explicit].map((page) => [page.url, page]));
+
+  assert.deepEqual(resolveInheritedFrontmatter(inherited, byUrl), {
+    tags: ["Networking"],
+    platforms: ["Linux"],
+    title: "Nmap"
+  });
+  assert.deepEqual(resolveInheritedFrontmatter(explicit, byUrl), {
+    tags: ["Wireshark"],
+    platforms: ["Linux"],
+    title: "Nmap"
+  });
+});
+
+test("canonicalizes known tag aliases deterministically", () => {
+  assert.equal(canonicalTag("Wirehark"), "Wireshark");
+  assert.equal(canonicalTag("hash-cracking"), "Hash Cracking");
+  assert.equal(tagKey("Hash Cracking"), tagKey("hash-cracking"));
+});
+
+test("does not invent values for absent list metadata", () => {
+  assert.deepEqual(uniqueStrings(undefined), []);
+  assert.deepEqual(uniqueStrings(null), []);
+  assert.deepEqual(uniqueStrings(["", "  ", "Linux"]), ["Linux"]);
+});


### PR DESCRIPTION
## What changed

- Add a shared metadata layer for Hugo-style `cascade` inheritance.
- Apply the nearest cascade to descendant pages while preserving explicit page metadata.
- Normalize known tag aliases, including `Wirehark` to `Wireshark`.
- Validate cascade shapes and legacy `tags= [...]` values in the content checker.
- Add regression tests and document the metadata policy.

## Why

The site already contains section-level cascade metadata, but the custom Astro content parser ignored it. That left most of the 751-page corpus without effective taxonomy and weakened tag navigation, search filters, and related-content behavior. The fix uses existing metadata without rewriting or inventing frontmatter.

## Validation

- 14 tests passing.
- Astro check passing.
- Content, links, assets, smoke, audit, and static build checks passing.
- Full build indexed all 751 pages and produced no undefined tag route.

The local `npm run validate` gate remains blocked only by the environment running Node 24.18.1 while `.node-version` requires Node 24.19.0.
