### PR TITLE
Add a shared content trust graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,15 @@ external URLs without blocking content builds.
 review queue to `.reports/content-review.md` plus a complete JSON report at
 `.reports/content-review.json`. It always reports missing `lastReviewed` values,
 marks pages stale when their effective review date is more than 12 months old,
-and never changes frontmatter or fails a content build. The scheduled `Content
-freshness review` workflow uploads the same reports weekly and adds a summary to
-the workflow run.
+and never changes frontmatter or fails a content build. The report uses the same
+effective metadata index as the site and includes field provenance plus a
+deterministic priority score, so inherited metadata cannot silently diverge
+between the site and maintenance checks. Reports use non-strict mode to record
+malformed cascade metadata for maintainers, while the site remains strict. The
+scheduled `Content freshness review` workflow uploads the same reports weekly
+and adds a summary to the workflow run. Markdown shows the oldest 100 queue
+entries by default (`--limit` changes this); JSON contains the complete corpus,
+field provenance, and priority data for future tooling.
 
 Content pages may optionally define `lastReviewed` (`YYYY-MM-DD`), `status`
 (`active`, `deprecated`, or `archived`), and `platforms` (a string or list of

--- a/scripts/check-content.mjs
+++ b/scripts/check-content.mjs
@@ -1,6 +1,6 @@
 import { readdir, readFile, stat } from "node:fs/promises";
 import path from "node:path";
-import { parseFrontmatter } from "../src/lib/frontmatter.mjs";
+import { buildContentIndex } from "../src/lib/content-index.mjs";
 import { isValidDateValue } from "../src/lib/date.mjs";
 import { parseCascade } from "../src/lib/metadata.mjs";
 
@@ -32,11 +32,11 @@ const pageStatuses = new Set(["active", "deprecated", "archived"]);
 const percentShortcodes = new Set(["children", "notice", "resources", "attachments"]);
 const angleShortcodes = new Set(["ref", "youtube", "gist"]);
 
-const markdownFiles = [];
 const contentFiles = [];
 const pages = [];
 const errors = [];
 const allowedWarnings = [];
+const reportedMetadataErrors = new Set();
 const flagged = new Map();
 const resourcePatterns = new Map();
 const policy = await readPolicy();
@@ -83,30 +83,30 @@ async function walk(dir) {
       continue;
     }
 
-    if (entry.name.endsWith(".md")) {
-      markdownFiles.push(absolute);
-    } else {
-      contentFiles.push(absolute);
-    }
+    if (!entry.name.endsWith(".md")) contentFiles.push(absolute);
   }
 }
 
-async function parsePages() {
-  for (const file of markdownFiles) {
-    const raw = await readFile(file, "utf8");
-    const relativeFile = slash(path.relative(contentDir, file));
-    const parsed = parseFrontmatter(raw, relativeFile);
-    const slug = slugFromFile(relativeFile);
+function parsePages() {
+  const index = buildContentIndex({
+    contentRoot: contentDir,
+    includeDrafts: true,
+    strict: false
+  });
 
+  for (const record of index.allPages) {
     pages.push({
-      file,
-      relativeFile,
-      sourceDir: slash(path.dirname(relativeFile)),
-      slug,
-      url: slug ? `/${slug}/` : "/",
-      title: String(parsed.data.title ?? "").trim(),
-      frontmatter: parsed.data,
-      body: parsed.content
+      file: record.file,
+      relativeFile: record.relativeFile,
+      sourceDir: record.sourceDir,
+      slug: record.slug,
+      url: record.url,
+      title: record.title,
+      frontmatter: record.frontmatter,
+      effectiveFrontmatter: record.effectiveFrontmatter,
+      metadataProvenance: record.metadataProvenance,
+      metadataErrors: record.metadataErrors,
+      body: record.body
     });
   }
 }
@@ -119,7 +119,14 @@ function validatePages() {
     matches.push(page.relativeFile);
     urls.set(page.url, matches);
 
-    if (page.url !== "/" && !page.title) {
+    for (const metadataError of page.metadataErrors) {
+      if (!reportedMetadataErrors.has(metadataError)) {
+        reportedMetadataErrors.add(metadataError);
+        errors.push(metadataError);
+      }
+    }
+
+    if (page.url !== "/" && !String(page.frontmatter.title ?? "").trim()) {
       errors.push(`${page.relativeFile}: missing frontmatter title`);
     }
 
@@ -159,7 +166,10 @@ function validatePages() {
       if (!valid) errors.push(`${page.relativeFile}: platforms must be a string or string array`);
     }
 
-    if (page.frontmatter.cascade !== undefined) {
+    if (
+      page.frontmatter.cascade !== undefined &&
+      !page.metadataErrors.some((error) => error.startsWith(`${page.relativeFile}:`))
+    ) {
       try {
         const cascade = parseCascade(page.frontmatter.cascade, page.relativeFile);
         validateCascadeFields(cascade, page.relativeFile);
@@ -167,11 +177,52 @@ function validatePages() {
         errors.push(error.message);
       }
     }
+
+    validateEffectiveMetadata(page);
   }
 
   for (const [url, files] of urls) {
     if (files.length > 1) {
       errors.push(`duplicate URL ${url}: ${files.join(", ")}`);
+    }
+  }
+}
+
+function validateEffectiveMetadata(page) {
+  const metadata = page.effectiveFrontmatter;
+
+  if (metadata.tags !== undefined) {
+    const tags = metadata.tags;
+    const valid =
+      typeof tags === "string" ||
+      (Array.isArray(tags) && tags.every((tag) => typeof tag === "string"));
+    if (!valid) errors.push(`${page.relativeFile}: effective tags must be a string or string array`);
+  }
+
+  if (metadata.weight !== undefined && !Number.isFinite(Number(metadata.weight))) {
+    errors.push(`${page.relativeFile}: effective weight must be numeric`);
+  }
+
+  for (const field of ["date", "lastReviewed"]) {
+    if (metadata[field] !== undefined && !isValidDateValue(metadata[field])) {
+      errors.push(`${page.relativeFile}: effective ${field} must start with a valid YYYY-MM-DD date`);
+    }
+  }
+
+  if (
+    metadata.status !== undefined &&
+    !pageStatuses.has(String(metadata.status).trim().toLowerCase())
+  ) {
+    errors.push(`${page.relativeFile}: effective status must be active, deprecated, or archived`);
+  }
+
+  if (metadata.platforms !== undefined) {
+    const platforms = metadata.platforms;
+    const valid =
+      typeof platforms === "string" ||
+      (Array.isArray(platforms) && platforms.every((platform) => typeof platform === "string"));
+    if (!valid) {
+      errors.push(`${page.relativeFile}: effective platforms must be a string or string array`);
     }
   }
 }
@@ -482,15 +533,6 @@ function normalizeResourceDirectory(value) {
     .split("/")
     .filter((part) => part && part !== "." && part !== "..")
     .join("/");
-}
-
-function slugFromFile(relativeFile) {
-  if (relativeFile === "_index.md") return "";
-  return relativeFile
-    .replace(/\/index\.md$/i, "")
-    .replace(/\/_index\.md$/i, "")
-    .replace(/\.md$/i, "")
-    .replace(/^_index$/i, "");
 }
 
 function slugify(value) {

--- a/scripts/content-review.mjs
+++ b/scripts/content-review.mjs
@@ -1,7 +1,7 @@
-import { appendFile, mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { parseFrontmatter } from "../src/lib/frontmatter.mjs";
+import { buildContentIndex } from "../src/lib/content-index.mjs";
 import {
   differenceInDays,
   normalizeDate,
@@ -12,36 +12,54 @@ export const DEFAULT_OUTPUT = ".reports/content-review.md";
 export const DEFAULT_JSON_OUTPUT = ".reports/content-review.json";
 export const DEFAULT_STALE_MONTHS = 12;
 export const DEFAULT_LIMIT = 100;
+export const DEFAULT_SECTION_WEIGHTS = Object.freeze({
+  cve: 4,
+  tools: 3,
+  commands: 2,
+  stuff: 1,
+  index: 0
+});
+export const REVIEW_PRIORITY = Object.freeze({
+  sectionMultiplier: 100,
+  missingReview: 2_000,
+  futureDate: 5_000,
+  metadataError: 10_000,
+  maxStaleAgeDays: 5_000,
+  highThreshold: 2_000,
+  criticalThreshold: 10_000
+});
 
 const contentRoot = path.join(process.cwd(), "content");
 const collator = new Intl.Collator("en", { sensitivity: "base", numeric: true });
 
 export async function collectContentPages(directory = contentRoot) {
-  const files = [];
-  await walkMarkdown(directory, files);
+  const index = buildContentIndex({
+    contentRoot: directory,
+    strict: false
+  });
 
-  const pages = [];
-  for (const file of files.sort((a, b) => collator.compare(a, b))) {
-    const raw = await readFile(file, "utf8");
-    const relativeFile = slash(path.relative(directory, file));
-    const parsed = parseFrontmatter(raw, relativeFile);
-    if (parsed.data.draft === true) continue;
-
-    const slug = slugFromFile(relativeFile);
-    pages.push({
-      relativeFile,
-      url: slug ? `/${slug}/` : "/",
-      title: String(parsed.data.title ?? "").trim() || titleFromSlug(slug || "Knowledge Base"),
-      section: slug.split("/")[0] || "index",
-      date: normalizeDate(parsed.data.date),
-      lastReviewed: normalizeDate(parsed.data.lastReviewed)
-    });
-  }
-
-  return pages;
+  return index.pages.map((page) => {
+    const metadata = page.effectiveFrontmatter;
+    return {
+      relativeFile: page.relativeFile,
+      url: page.url,
+      title: page.title,
+      section: page.section || "index",
+      date: normalizeDate(metadata.date),
+      lastReviewed: normalizeDate(metadata.lastReviewed),
+      tags: Array.isArray(metadata.tags) ? metadata.tags : [],
+      platforms: Array.isArray(metadata.platforms) ? metadata.platforms : [],
+      status: metadata.status ?? null,
+      metadataProvenance: page.metadataProvenance,
+      metadataErrors: page.metadataErrors
+    };
+  });
 }
 
-export function classifyReviewPage(page, { asOf, staleBefore }) {
+export function classifyReviewPage(
+  page,
+  { asOf, staleBefore, sectionWeights = DEFAULT_SECTION_WEIGHTS }
+) {
   const normalizedAsOf = normalizeDate(asOf);
   const normalizedStaleBefore = normalizeDate(staleBefore);
   if (!normalizedAsOf || !normalizedStaleBefore) {
@@ -52,11 +70,25 @@ export function classifyReviewPage(page, { asOf, staleBefore }) {
   const missingReview = !page.lastReviewed;
   const stale = Boolean(effectiveDate && effectiveDate < normalizedStaleBefore);
   const futureDate = Boolean(effectiveDate && effectiveDate > normalizedAsOf);
+  const metadataErrors = Array.isArray(page.metadataErrors) ? page.metadataErrors : [];
   const reasons = [];
 
   if (missingReview) reasons.push("missing-lastReviewed");
   if (stale) reasons.push("stale");
   if (futureDate) reasons.push("future-date");
+  if (metadataErrors.length) reasons.push("metadata-error");
+
+  const priority = calculateReviewPriority(
+    {
+      ...page,
+      missingReview,
+      stale,
+      futureDate,
+      metadataErrors,
+      ageDays: effectiveDate ? differenceInDays(normalizedAsOf, effectiveDate) : null
+    },
+    sectionWeights
+  );
 
   return {
     ...page,
@@ -67,8 +99,56 @@ export function classifyReviewPage(page, { asOf, staleBefore }) {
     missingReview,
     stale,
     futureDate,
-    needsReview: missingReview || stale,
-    reasons
+    metadataErrors,
+    needsReview: missingReview || stale || metadataErrors.length > 0,
+    reasons,
+    ...priority
+  };
+}
+
+export function calculateReviewPriority(page, sectionWeights = DEFAULT_SECTION_WEIGHTS) {
+  const hasIssue = page.missingReview || page.stale || page.futureDate || page.metadataErrors?.length;
+  if (!hasIssue) {
+    return { priorityScore: 0, priorityTier: "current", priorityReasons: [] };
+  }
+
+  const reasons = [];
+  let score = 0;
+  const sectionWeight = Number(sectionWeights[page.section] ?? 0);
+
+  if (sectionWeight > 0) {
+    score += sectionWeight * REVIEW_PRIORITY.sectionMultiplier;
+    reasons.push(`section-${page.section}`);
+  }
+  if (page.metadataErrors?.length) {
+    score += REVIEW_PRIORITY.metadataError;
+    reasons.push("metadata-error");
+  }
+  if (page.futureDate) {
+    score += REVIEW_PRIORITY.futureDate;
+    reasons.push("future-date");
+  }
+  if (page.missingReview) {
+    score += REVIEW_PRIORITY.missingReview;
+    reasons.push("missing-lastReviewed");
+  }
+  if (page.stale) {
+    score += Math.min(
+      Math.max(page.ageDays ?? 0, 0),
+      REVIEW_PRIORITY.maxStaleAgeDays
+    );
+    reasons.push("stale-age");
+  }
+
+  return {
+    priorityScore: score,
+    priorityTier:
+      score >= REVIEW_PRIORITY.criticalThreshold
+        ? "critical"
+        : score >= REVIEW_PRIORITY.highThreshold
+          ? "high"
+          : "normal",
+    priorityReasons: reasons
   };
 }
 
@@ -87,7 +167,11 @@ export function createReviewReport(pages, options = {}) {
 
   const staleBefore = subtractMonths(asOf, staleMonths);
   const reviewedPages = pages.map((page) =>
-    classifyReviewPage(page, { asOf, staleBefore })
+    classifyReviewPage(page, {
+      asOf,
+      staleBefore,
+      sectionWeights: options.sectionWeights ?? DEFAULT_SECTION_WEIGHTS
+    })
   );
   reviewedPages.sort(compareReviewPages);
 
@@ -106,8 +190,15 @@ export function createReviewReport(pages, options = {}) {
       missingLastReviewed: reviewedPages.filter((page) => page.missingReview).length,
       stale: reviewedPages.filter((page) => page.stale).length,
       futureDates: futureDates.length,
+      metadataErrors: reviewedPages.filter((page) => page.metadataErrors.length).length,
       reviewed: reviewedPages.filter((page) => page.lastReviewed).length,
-      current: current.length
+      current: current.length,
+      priorityTiers: Object.fromEntries(
+        ["critical", "high", "normal", "current"].map((tier) => [
+          tier,
+          reviewedPages.filter((page) => page.priorityTier === tier).length
+        ])
+      )
     },
     pages: reviewedPages
   };
@@ -122,7 +213,16 @@ export function compareReviewPages(a, b) {
   };
 
   return (
+    (b.priorityScore ?? 0) - (a.priorityScore ?? 0) ||
     priority(a) - priority(b) ||
+    (a.effectiveDate ?? "9999-12-31").localeCompare(b.effectiveDate ?? "9999-12-31") ||
+    collator.compare(a.title, b.title) ||
+    collator.compare(a.url, b.url)
+  );
+}
+
+export function compareReviewAge(a, b) {
+  return (
     (a.effectiveDate ?? "9999-12-31").localeCompare(b.effectiveDate ?? "9999-12-31") ||
     collator.compare(a.title, b.title) ||
     collator.compare(a.url, b.url)
@@ -131,7 +231,7 @@ export function compareReviewPages(a, b) {
 
 export function renderMarkdown(report) {
   const queue = report.pages.filter((page) => page.needsReview);
-  const visible = queue.slice(0, report.limit);
+  const visible = [...queue].sort(compareReviewAge).slice(0, report.limit);
   const lines = [
     "# Content review queue",
     "",
@@ -142,7 +242,9 @@ export function renderMarkdown(report) {
     "- Missing `lastReviewed`: " + report.summary.missingLastReviewed,
     `- Stale: ${report.summary.stale}`,
     `- Future dates: ${report.summary.futureDates}`,
+    `- Metadata errors: ${report.summary.metadataErrors}`,
     `- Reviewed pages: ${report.summary.reviewed}`,
+    `- Priority tiers: ${report.summary.priorityTiers.critical} critical, ${report.summary.priorityTiers.high} high, ${report.summary.priorityTiers.normal} normal, ${report.summary.priorityTiers.current} current`,
     ""
   ];
 
@@ -158,15 +260,15 @@ export function renderMarkdown(report) {
   }
 
   lines.push(
-    `Showing the oldest ${visible.length} queue entries. The JSON report contains all ${queue.length} queue entries and any future-date data issues.`,
+    `Showing the oldest ${visible.length} queue entries. The JSON report contains all ${queue.length} queue entries, priority scores, and any future-date data issues.`,
     "",
-    "| # | Page | Section | Effective date | Last reviewed | Age (days) | Reason |",
-    "| ---: | --- | --- | --- | --- | ---: | --- |"
+    "| # | Priority | Page | Section | Effective date | Last reviewed | Age (days) | Reason |",
+    "| ---: | --- | --- | --- | --- | --- | ---: | --- |"
   );
 
   visible.forEach((page, index) => {
     lines.push(
-      `| ${index + 1} | [${escapeTable(page.title)}](${page.url}) | ${escapeTable(
+      `| ${index + 1} | ${page.priorityTier} (${page.priorityScore}) | [${escapeTable(page.title)}](${page.url}) | ${escapeTable(
         page.section
       )} | ${page.effectiveDate ?? "—"} | ${page.lastReviewed ?? "—"} | ${
         page.ageDays ?? "—"
@@ -185,7 +287,9 @@ export function renderSummary(report) {
     `- Pages requiring review: ${report.summary.needsReview}`,
     `- Missing lastReviewed: ${report.summary.missingLastReviewed}`,
     `- Stale: ${report.summary.stale}`,
-    `- Future dates: ${report.summary.futureDates}`
+    `- Future dates: ${report.summary.futureDates}`,
+    `- Metadata errors: ${report.summary.metadataErrors}`,
+    `- Critical/high priority: ${report.summary.priorityTiers.critical}/${report.summary.priorityTiers.high}`
   ].join("\n");
 }
 
@@ -250,15 +354,6 @@ export function parseArguments(argv = []) {
   return options;
 }
 
-async function walkMarkdown(directory, files) {
-  const entries = await readdir(directory, { withFileTypes: true });
-  for (const entry of entries) {
-    const absolute = path.join(directory, entry.name);
-    if (entry.isDirectory()) await walkMarkdown(absolute, files);
-    else if (entry.name.endsWith(".md")) files.push(absolute);
-  }
-}
-
 async function writeOutput(file, content) {
   await mkdir(path.dirname(file), { recursive: true });
   await writeFile(file, content);
@@ -283,28 +378,6 @@ function currentUtcDate() {
 
 function escapeTable(value) {
   return String(value).replaceAll("|", "\\|").replaceAll("\n", " ");
-}
-
-function slugFromFile(relativeFile) {
-  if (relativeFile === "_index.md") return "";
-  return relativeFile
-    .replace(/\/index\.md$/i, "")
-    .replace(/\/_index\.md$/i, "")
-    .replace(/\.md$/i, "")
-    .replace(/^_index$/i, "");
-}
-
-function titleFromSlug(slug) {
-  return slug
-    .split("/")
-    .filter(Boolean)
-    .pop()
-    ?.replace(/[-_]+/g, " ")
-    .replace(/\b\w/g, (character) => character.toUpperCase()) ?? "Knowledge Base";
-}
-
-function slash(value) {
-  return value.replace(/\\/g, "/");
 }
 
 const isMain =

--- a/src/lib/content-index.mjs
+++ b/src/lib/content-index.mjs
@@ -1,0 +1,150 @@
+import fs from "node:fs";
+import path from "node:path";
+import { parseFrontmatter } from "./frontmatter.mjs";
+import { resolveInheritedMetadata } from "./metadata.mjs";
+
+const collator = new Intl.Collator("en", { sensitivity: "base", numeric: true });
+
+export function buildContentIndex(options = {}) {
+  const contentRoot = path.resolve(options.contentRoot ?? path.join(process.cwd(), "content"));
+  const strict = options.strict ?? true;
+  const allPages = listMarkdown(contentRoot)
+    .sort((a, b) => collator.compare(a, b))
+    .map((file) => parseRecord(file, contentRoot));
+  const duplicateUrls = findDuplicateUrls(allPages);
+  if (strict && duplicateUrls.length) {
+    throw new Error(
+      duplicateUrls.map(({ url, files }) => `duplicate URL ${url}: ${files.join(", ")}`).join("\n")
+    );
+  }
+  const allByUrl = new Map(allPages.map((page) => [page.url, page]));
+
+  for (const page of allPages) {
+    page.parentUrl = findParentUrl(page.url, allByUrl);
+  }
+
+  for (const page of allPages) {
+    const resolved = resolveInheritedMetadata(page, allByUrl, { strict });
+    page.effectiveFrontmatter = resolved.frontmatter;
+    page.metadataProvenance = resolved.provenance;
+    page.metadataErrors = resolved.errors;
+    page.title = normalizeTitle(page.effectiveFrontmatter.title) || titleFromSlug(page.slug || "Knowledge Base");
+    page.description = String(page.effectiveFrontmatter.description ?? "");
+  }
+
+  const pages = allPages.filter((page) => page.effectiveFrontmatter.draft !== true);
+  const byUrl = new Map(pages.map((page) => [page.url, page]));
+
+  for (const page of pages) {
+    page.children = [];
+    page.parentUrl = findParentUrl(page.url, byUrl);
+    if (page.parentUrl) byUrl.get(page.parentUrl)?.children.push(page);
+  }
+
+  for (const page of pages) page.children.sort(compareContentPages);
+  pages.sort(compareContentPages);
+
+  return {
+    contentRoot,
+    allPages,
+    pages: options.includeDrafts ? allPages : pages,
+    byUrl
+  };
+}
+
+function parseRecord(file, contentRoot) {
+  const relativeFile = slash(path.relative(contentRoot, file));
+  const parsed = parseFrontmatter(fs.readFileSync(file, "utf8"), relativeFile);
+  const slug = slugFromFile(relativeFile);
+
+  return {
+    file,
+    relativeFile,
+    sourceDir: slash(path.dirname(relativeFile)),
+    slug,
+    url: slug ? `/${slug}/` : "/",
+    section: slug.split("/")[0] ?? "",
+    body: parsed.content.trim(),
+    frontmatter: parsed.data,
+    effectiveFrontmatter: parsed.data,
+    metadataProvenance: {},
+    metadataErrors: [],
+    title: "",
+    description: "",
+    parentUrl: null,
+    children: []
+  };
+}
+
+export function compareContentPages(a, b) {
+  const weightA = normalizeWeight(a.effectiveFrontmatter?.weight);
+  const weightB = normalizeWeight(b.effectiveFrontmatter?.weight);
+  return weightA - weightB || collator.compare(a.title, b.title) || collator.compare(a.url, b.url);
+}
+
+export function normalizeWeight(value) {
+  if (value === null || value === undefined || value === "") {
+    return Number.MAX_SAFE_INTEGER;
+  }
+  const weight = Number(value);
+  return Number.isFinite(weight) ? weight : Number.MAX_SAFE_INTEGER;
+}
+
+function findDuplicateUrls(pages) {
+  const filesByUrl = new Map();
+  for (const page of pages) {
+    const files = filesByUrl.get(page.url) ?? [];
+    files.push(page.relativeFile);
+    filesByUrl.set(page.url, files);
+  }
+  return [...filesByUrl.entries()]
+    .filter(([, files]) => files.length > 1)
+    .map(([url, files]) => ({ url, files }));
+}
+
+function listMarkdown(directory) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const absolute = path.join(directory, entry.name);
+    if (entry.isDirectory()) return listMarkdown(absolute);
+    return entry.name.endsWith(".md") ? [absolute] : [];
+  });
+}
+
+function findParentUrl(url, byUrl) {
+  if (url === "/") return null;
+  const parts = url.replace(/^\/|\/$/g, "").split("/");
+  while (parts.length > 0) {
+    parts.pop();
+    const candidate = parts.length ? `/${parts.join("/")}/` : "/";
+    if (byUrl.has(candidate)) return candidate;
+  }
+  return "/";
+}
+
+function slugFromFile(relativeFile) {
+  if (relativeFile === "_index.md") return "";
+  return relativeFile
+    .replace(/\/index\.md$/i, "")
+    .replace(/\/_index\.md$/i, "")
+    .replace(/\.md$/i, "")
+    .replace(/^_index$/i, "");
+}
+
+function titleFromSlug(slug) {
+  return (
+    slug
+      .split("/")
+      .filter(Boolean)
+      .pop()
+      ?.replace(/[-_]+/g, " ")
+      .replace(/\b\w/g, (character) => character.toUpperCase()) ?? "Knowledge Base"
+  );
+}
+
+function normalizeTitle(value) {
+  return String(value ?? "").trim();
+}
+
+function slash(value) {
+  return value.replace(/\\/g, "/");
+}

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -2,17 +2,16 @@ import fs from "node:fs";
 import path from "node:path";
 import MarkdownIt from "markdown-it";
 import anchor from "markdown-it-anchor";
-import { parseFrontmatter } from "./frontmatter.mjs";
+import { buildContentIndex, normalizeWeight } from "./content-index.mjs";
 import { normalizeDate } from "./date.mjs";
 import {
   canonicalTag,
-  resolveInheritedFrontmatter,
   tagKey,
   uniqueStrings
 } from "./metadata.mjs";
 
-const root = process.cwd();
-const contentRoot = path.join(root, "content");
+const contentRoot = path.join(process.cwd(), "content");
+const pageCollator = new Intl.Collator("en", { sensitivity: "base", numeric: true });
 
 export type KbPage = {
   file: string;
@@ -30,6 +29,7 @@ export type KbPage = {
   status?: "active" | "deprecated" | "archived";
   platforms: string[];
   tags: string[];
+  metadataProvenance: Record<string, { source: string; kind: "cascade" | "explicit" }>;
   parentUrl: string | null;
   section: string;
   children: KbPage[];
@@ -39,6 +39,24 @@ export type KbPage = {
 let cache: KbPage[] | null = null;
 let urlMap: Map<string, KbPage> | null = null;
 let refMap: Map<string, KbPage[]> | null = null;
+
+type ContentRecord = {
+  file: string;
+  relativeFile: string;
+  sourceDir: string;
+  slug: string;
+  url: string;
+  section: string;
+  body: string;
+  effectiveFrontmatter: Record<string, any>;
+  metadataProvenance: Record<string, { source: string; kind: "cascade" | "explicit" }>;
+  parentUrl: string | null;
+  children: ContentRecord[];
+};
+
+type ContentIndex = {
+  pages: ContentRecord[];
+};
 
 const md = new MarkdownIt({
   html: true,
@@ -65,30 +83,18 @@ md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
 export function getPages() {
   if (cache) return cache;
 
-  const files = listMarkdown(contentRoot);
-  const allPages = files.map(parsePage);
-  const allByUrl = new Map(allPages.map((page) => [page.url, page]));
-
-  for (const page of allPages) {
-    page.parentUrl = findParentUrl(page.url, allByUrl);
-  }
-
-  for (const page of allPages) {
-    hydratePage(page, resolveInheritedFrontmatter(page, allByUrl));
-  }
-
-  const pages = allPages.filter((page) => page.frontmatter.draft !== true);
+  const index = buildContentIndex({ contentRoot }) as ContentIndex;
+  const pageMap = new Map(index.pages.map((record) => [record.url, toKbPage(record)]));
+  const pages = [...pageMap.values()];
   const byUrl = new Map(pages.map((page) => [page.url, page]));
 
-  for (const page of pages) {
-    page.children = [];
-    page.parentUrl = findParentUrl(page.url, byUrl);
-    if (page.parentUrl) {
-      byUrl.get(page.parentUrl)?.children.push(page);
-    }
-  }
-
-  for (const page of pages) {
+  for (const record of index.pages) {
+    const page = pageMap.get(record.url);
+    if (!page) continue;
+    page.parentUrl = record.parentUrl;
+    page.children = record.children
+      .map((child) => pageMap.get(child.url))
+      .filter((child): child is KbPage => Boolean(child));
     page.children.sort(sortPages);
     page.breadcrumbs = buildBreadcrumbs(page, byUrl);
   }
@@ -133,7 +139,7 @@ export function getPopularTags(limit = 18) {
 }
 
 export function getPagesByTag(tag: string) {
-  const requested = tagSlug(tag);
+  const requested = tagSlug(canonicalTag(tag));
   return getPages()
     .filter((page) => page.tags.some((item) => tagSlug(item) === requested))
     .sort(sortPages);
@@ -177,56 +183,39 @@ export function renderInlineMarkdown(source: string) {
 }
 
 export function tagSlug(tag: string) {
-  return tagKey(tag);
+  return tagKey(canonicalTag(tag));
 }
 
 export function sortPages(a: KbPage, b: KbPage) {
   if (a.weight !== b.weight) return a.weight - b.weight;
-  return a.title.localeCompare(b.title);
+  return pageCollator.compare(a.title, b.title) || pageCollator.compare(a.url, b.url);
 }
 
-function parsePage(file: string): KbPage {
-  const relativeFile = slash(path.relative(contentRoot, file));
-  const raw = fs.readFileSync(file, "utf8");
-  const parsed = parseFrontmatter(raw, relativeFile);
-  const slug = slugFromFile(relativeFile);
-  const url = slug ? `/${slug}/` : "/";
-
+function toKbPage(record: ContentRecord): KbPage {
+  const frontmatter = record.effectiveFrontmatter;
+  const title = normalizeTitle(frontmatter.title) || titleFromSlug(record.slug || "Knowledge Base");
   return {
-    file,
-    relativeFile,
-    sourceDir: slash(path.dirname(relativeFile)),
-    slug,
-    url,
-    title: "",
-    description: "",
-    body: parsed.content.trim(),
-    frontmatter: parsed.data,
-    weight: Number.MAX_SAFE_INTEGER,
-    date: undefined,
-    lastReviewed: undefined,
-    status: undefined,
-    platforms: [],
-    tags: [],
-    parentUrl: null,
-    section: slug.split("/")[0] ?? "",
+    file: record.file,
+    relativeFile: record.relativeFile,
+    sourceDir: record.sourceDir,
+    slug: record.slug,
+    url: record.url,
+    title,
+    description: String(frontmatter.description ?? ""),
+    body: record.body,
+    frontmatter,
+    weight: normalizeWeight(frontmatter.weight),
+    date: normalizeDate(frontmatter.date),
+    lastReviewed: normalizeDate(frontmatter.lastReviewed),
+    status: normalizeStatus(frontmatter.status),
+    platforms: uniqueStrings(frontmatter.platforms),
+    tags: [...new Set(uniqueStrings(frontmatter.tags).map(canonicalTag))],
+    metadataProvenance: record.metadataProvenance,
+    parentUrl: record.parentUrl,
+    section: record.section,
     children: [],
     breadcrumbs: []
   };
-}
-
-function hydratePage(page: KbPage, frontmatter: Record<string, any>) {
-  const title = normalizeTitle(frontmatter.title) || titleFromSlug(page.slug || "Knowledge Base");
-
-  page.frontmatter = frontmatter;
-  page.title = title;
-  page.description = String(frontmatter.description ?? "");
-  page.weight = Number(frontmatter.weight ?? Number.MAX_SAFE_INTEGER);
-  page.date = normalizeDate(frontmatter.date);
-  page.lastReviewed = normalizeDate(frontmatter.lastReviewed);
-  page.status = normalizeStatus(frontmatter.status);
-  page.platforms = uniqueStrings(frontmatter.platforms);
-  page.tags = [...new Set(uniqueStrings(frontmatter.tags).map(canonicalTag))];
 }
 
 function preprocessShortcodes(source: string, page: KbPage) {
@@ -435,34 +424,6 @@ function buildRefMap(pages: KbPage[]) {
   return map;
 }
 
-function listMarkdown(dir: string): string[] {
-  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-    const absolute = path.join(dir, entry.name);
-    if (entry.isDirectory()) return listMarkdown(absolute);
-    return entry.name.endsWith(".md") ? [absolute] : [];
-  });
-}
-
-function slugFromFile(relativeFile: string) {
-  if (relativeFile === "_index.md") return "";
-  return relativeFile
-    .replace(/\/index\.md$/i, "")
-    .replace(/\/_index\.md$/i, "")
-    .replace(/\.md$/i, "")
-    .replace(/^_index$/i, "");
-}
-
-function findParentUrl(url: string, byUrl: Map<string, KbPage>) {
-  if (url === "/") return null;
-  const parts = url.replace(/^\/|\/$/g, "").split("/");
-  while (parts.length > 0) {
-    parts.pop();
-    const candidate = parts.length ? `/${parts.join("/")}/` : "/";
-    if (byUrl.has(candidate)) return candidate;
-  }
-  return "/";
-}
-
 function titleFromSlug(slug: string) {
   return slug
     .split("/")
@@ -478,7 +439,9 @@ function normalizeTitle(value: unknown) {
 
 function normalizeStatus(value: unknown): KbPage["status"] {
   const status = String(value ?? "").trim().toLowerCase();
-  return status === "deprecated" || status === "archived" ? status : undefined;
+  return status === "active" || status === "deprecated" || status === "archived"
+    ? status
+    : undefined;
 }
 
 function slugify(value: string) {

--- a/src/lib/metadata.mjs
+++ b/src/lib/metadata.mjs
@@ -35,13 +35,22 @@ export function parseCascade(value, file = "content") {
 }
 
 export function resolveInheritedFrontmatter(page, byUrl) {
+  return resolveInheritedMetadata(page, byUrl).frontmatter;
+}
+
+export function resolveInheritedMetadata(page, byUrl, options = {}) {
+  const strict = options.strict ?? true;
   const ancestors = [];
   const visited = new Set();
+  const errors = [];
   let current = page.parentUrl ? byUrl.get(page.parentUrl) : undefined;
 
   while (current) {
     if (visited.has(current.url)) {
-      throw new Error(`metadata inheritance cycle detected at ${current.url}`);
+      const error = new Error(`metadata inheritance cycle detected at ${current.url}`);
+      if (strict) throw error;
+      errors.push(error.message);
+      break;
     }
     visited.add(current.url);
     ancestors.unshift(current);
@@ -49,14 +58,47 @@ export function resolveInheritedFrontmatter(page, byUrl) {
   }
 
   const inherited = {};
+  const provenance = {};
   for (const ancestor of ancestors) {
-    Object.assign(
-      inherited,
-      parseCascade(ancestor.frontmatter.cascade, ancestor.relativeFile)
-    );
+    let cascade;
+    try {
+      cascade = parseCascade(ancestor.frontmatter.cascade, ancestor.relativeFile);
+    } catch (error) {
+      if (strict) throw error;
+      errors.push(error.message);
+      continue;
+    }
+
+    for (const [field, value] of Object.entries(cascade)) {
+      inherited[field] = value;
+      provenance[field] = {
+        source: ancestor.relativeFile,
+        kind: "cascade"
+      };
+    }
   }
 
-  return normalizeFrontmatter({ ...inherited, ...page.frontmatter });
+  if (page.frontmatter.cascade !== undefined) {
+    try {
+      parseCascade(page.frontmatter.cascade, page.relativeFile);
+    } catch (error) {
+      if (strict) throw error;
+      errors.push(error.message);
+    }
+  }
+
+  for (const field of Object.keys(page.frontmatter)) {
+    provenance[field] = {
+      source: page.relativeFile,
+      kind: "explicit"
+    };
+  }
+
+  return {
+    frontmatter: normalizeFrontmatter({ ...inherited, ...page.frontmatter }),
+    provenance,
+    errors
+  };
 }
 
 export function normalizeFrontmatter(frontmatter) {
@@ -91,7 +133,9 @@ export function uniqueStrings(value) {
 }
 
 function isPlainObject(value) {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }
 
 function slugify(value) {

--- a/test/content-index.test.mjs
+++ b/test/content-index.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { buildContentIndex, normalizeWeight } from "../src/lib/content-index.mjs";
+
+test("builds the full effective metadata index with provenance", () => {
+  const index = buildContentIndex();
+
+  assert.equal(index.pages.length, 751);
+  assert.equal(index.pages.filter((page) => page.effectiveFrontmatter.tags?.length).length, 750);
+
+  const inherited = index.pages.find(
+    (page) => page.metadataProvenance.tags?.kind === "cascade"
+  );
+  assert.ok(inherited);
+  assert.ok(inherited.effectiveFrontmatter.tags.length > 0);
+  assert.equal(inherited.metadataErrors.length, 0);
+  assert.equal(inherited.metadataProvenance.tags.source.endsWith("_index.md"), true);
+});
+
+test("keeps absent weights unordered and rejects duplicate URLs in strict mode", async () => {
+  assert.equal(normalizeWeight(null), Number.MAX_SAFE_INTEGER);
+  assert.equal(normalizeWeight(""), Number.MAX_SAFE_INTEGER);
+  assert.equal(normalizeWeight("12"), 12);
+
+  const directory = await mkdtemp(path.join(os.tmpdir(), "kb-content-duplicates-"));
+  try {
+    await mkdir(path.join(directory, "tools", "example"), { recursive: true });
+    await writeFile(path.join(directory, "tools", "example.md"), "---\ntitle: Flat\n---\n");
+    await writeFile(
+      path.join(directory, "tools", "example", "index.md"),
+      "---\ntitle: Nested\n---\n"
+    );
+
+    assert.throws(() => buildContentIndex({ contentRoot: directory }), /duplicate URL/);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("preserves explicit overrides and reports non-strict metadata errors", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "kb-content-index-"));
+
+  try {
+    await mkdir(path.join(directory, "tools", "example"), { recursive: true });
+    await writeFile(
+      path.join(directory, "_index.md"),
+      "---\ncascade:\n  tags: [Tools]\n  platforms: [Linux]\n---\n"
+    );
+    await writeFile(
+      path.join(directory, "tools", "_index.md"),
+      "---\ncascade:\n  tags: [Framework]\n  status: deprecated\n---\n"
+    );
+    await writeFile(
+      path.join(directory, "tools", "example", "index.md"),
+      "---\ntitle: Example\ntags: []\n---\nBody\n"
+    );
+
+    const index = buildContentIndex({ contentRoot: directory });
+    const example = index.pages.find((page) => page.url === "/tools/example/");
+    assert.deepEqual(example.effectiveFrontmatter.tags, []);
+    assert.deepEqual(example.effectiveFrontmatter.platforms, ["Linux"]);
+    assert.equal(example.effectiveFrontmatter.status, "deprecated");
+    assert.equal(example.metadataProvenance.tags.source, "tools/example/index.md");
+    assert.equal(example.metadataProvenance.status.source, "tools/_index.md");
+
+    await writeFile(
+      path.join(directory, "tools", "_index.md"),
+      "---\ncascade: invalid cascade\n---\n"
+    );
+    const nonStrict = buildContentIndex({ contentRoot: directory, strict: false });
+    assert.ok(
+      nonStrict.pages.some(
+        (page) => page.url === "/tools/" && page.metadataErrors.some((error) => /cascade/.test(error))
+      )
+    );
+    assert.throws(() => buildContentIndex({ contentRoot: directory }), /cascade/);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/test/content-review.test.mjs
+++ b/test/content-review.test.mjs
@@ -1,10 +1,14 @@
 import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 import {
   collectContentPages,
   createReviewReport,
   classifyReviewPage,
-  renderMarkdown
+  renderMarkdown,
+  run
 } from "../scripts/content-review.mjs";
 import {
   differenceInDays,
@@ -86,7 +90,7 @@ test("indexes the full publishable content corpus", async () => {
   const pages = await collectContentPages();
   const report = createReviewReport(pages, { asOf });
 
-  assert.ok(pages.length >= 751);
+  assert.equal(pages.length, 751);
   assert.equal(report.pages.length, pages.length);
   assert.equal(
     report.summary.needsReview,
@@ -97,4 +101,44 @@ test("indexes the full publishable content corpus", async () => {
     report.pages.filter((page) => page.missingReview).length
   );
   assert.equal(report.summary.totalPages, report.pages.length);
+  assert.equal(new Set(report.pages.map((page) => page.url)).size, 751);
+  assert.equal(pages.filter((page) => page.metadataProvenance.tags?.kind === "cascade").length, 521);
+  assert.equal(report.summary.priorityTiers.high > 0, true);
+});
+
+test("ranks higher-risk sections ahead of equally old pages", () => {
+  const report = createReviewReport(
+    [
+      { title: "Tool", url: "/tools/tool/", section: "tools", date: "2020-01-01", lastReviewed: null },
+      { title: "CVE", url: "/cve/cve-2020/", section: "cve", date: "2020-01-01", lastReviewed: null }
+    ],
+    { asOf }
+  );
+
+  assert.equal(report.pages[0].title, "CVE");
+  assert.ok(report.pages[0].priorityScore > report.pages[1].priorityScore);
+});
+
+test("writes a complete JSON corpus report", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "kb-content-review-"));
+
+  try {
+    const jsonFile = path.join(directory, "review.json");
+    await run([
+      "--as-of",
+      asOf,
+      "--output",
+      path.join(directory, "review.md"),
+      "--json",
+      jsonFile
+    ]);
+
+    const report = JSON.parse(await readFile(jsonFile, "utf8"));
+    assert.equal(report.pages.length, 751);
+    assert.equal(new Set(report.pages.map((page) => page.url)).size, 751);
+    assert.equal(report.summary.totalPages, 751);
+    assert.equal(report.summary.needsReview, 751);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## What changed

- Add a shared effective content index with cascade inheritance, field provenance, stable hierarchy, duplicate-URL detection, and strict/non-strict metadata errors.
- Use the index in the Astro runtime, content validation, and the maintainer freshness report.
- Extend the review JSON manifest with provenance, deterministic priority scores, and complete-corpus assertions while keeping the Markdown queue oldest-first by default.
- Preserve strict frontmatter/title validation and null-weight ordering behavior.
- Document the trust graph and review policy in the README.

## Why

Runtime rendering, validation, and the maintainer review queue previously parsed metadata independently. Centralizing effective metadata prevents inherited tags, dates, and other fields from drifting between public pages and maintenance tooling.

## Validation

- `npm test` — 19 passing tests
- `npm run check`
- `npm run check:content`
- `npm run content:review -- --as-of 2026-08-05`
- `npm run check:links`
- `npm run check:assets`
- `npm run build` — 751 pages indexed
- `npm run smoke`
- `npm run audit:known`

The local `npm run doctor` remains unavailable because this shell has Node 24.18.1 while `.node-version` pins 24.19.0; CI uses the pinned version.
