### PR TITLE
add investigation navigator

### DIFF
--- a/.github/workflows/content-review.yml
+++ b/.github/workflows/content-review.yml
@@ -31,11 +31,20 @@ jobs:
             --json .reports/content-review.json \
             --summary-file "$GITHUB_STEP_SUMMARY"
 
+      - name: Generate content relationship graph
+        run: |
+          npm run content:graph -- \
+            --output .reports/content-graph.md \
+            --json .reports/content-graph.json \
+            --summary-file "$GITHUB_STEP_SUMMARY"
+
       - name: Upload content review reports
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: content-review-queue
-          path: .reports/content-review.*
+          path: |
+            .reports/content-review.*
+            .reports/content-graph.*
           if-no-files-found: warn
           retention-days: 30

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ npm run check:links
 npm run audit:known
 npm run sysinternals:check
 npm run content:review
+npm run content:graph
 npm test
 npm run doctor
 npm run build
@@ -63,6 +64,14 @@ scheduled `Content freshness review` workflow uploads the same reports weekly
 and adds a summary to the workflow run. Markdown shows the oldest 100 queue
 entries by default (`--limit` changes this); JSON contains the complete corpus,
 field provenance, and priority data for future tooling.
+
+`npm run content:graph` builds the same canonical page index into a deterministic
+relationship report at `.reports/content-graph.md` and a complete
+`.reports/content-graph.json`. It includes explicit Markdown and `ref` shortcode
+references, incoming/outgoing counts, and pages without explicit references.
+Those pages are not necessarily disconnected: the site still provides hierarchy
+and shared-tag navigation. The weekly content review workflow uploads both graph
+formats alongside the freshness queue.
 
 Content pages may optionally define `lastReviewed` (`YYYY-MM-DD`), `status`
 (`active`, `deprecated`, or `archived`), and `platforms` (a string or list of

--- a/package.json
+++ b/package.json
@@ -15,11 +15,12 @@
     "audit:known": "node scripts/check-audit.mjs",
     "doctor": "node scripts/doctor.mjs",
     "content:review": "node scripts/content-review.mjs",
+    "content:graph": "node scripts/content-graph.mjs",
     "test": "node --test test/*.test.mjs",
     "sysinternals:check": "node scripts/sync-sysinternals.mjs --check",
     "sysinternals:sync": "node scripts/sync-sysinternals.mjs --write",
     "smoke": "node scripts/smoke-build.mjs",
-    "validate": "npm run doctor && npm test && npm run check && npm run check:content && npm run check:links && npm run build && npm run check:assets && npm run smoke && npm run audit:known"
+    "validate": "npm run doctor && npm test && npm run check && npm run check:content && npm run check:links && npm run content:graph && npm run build && npm run check:assets && npm run smoke && npm run audit:known"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.10",

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -1,29 +1,39 @@
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
-import MarkdownIt from "markdown-it";
+import { buildContentIndex } from "../src/lib/content-index.mjs";
 import { parseFrontmatter } from "../src/lib/frontmatter.mjs";
+import {
+  collectAnchors,
+  collectMarkdownTargets,
+  createContentResolver,
+  isInternalTarget,
+  slugify,
+  splitTarget
+} from "../src/lib/content-graph.mjs";
 
 const root = process.cwd();
 const contentDir = path.join(root, "content");
-const md = new MarkdownIt({ html: true, linkify: false });
+const index = buildContentIndex({ contentRoot: contentDir, strict: false });
+const contentPages = index.pages.map((page) => ({
+  ...page,
+  anchors: collectAnchors(page.body)
+}));
+const pagesByFile = new Map(contentPages.map((page) => [path.resolve(page.file), page]));
+const resolver = createContentResolver({
+  root,
+  contentRoot: contentDir,
+  pages: contentPages
+});
 const markdownFiles = [
-  ...listMarkdown(contentDir),
+  ...contentPages.map((page) => page.file),
   path.join(root, "README.md")
 ].filter((file) => existsSync(file));
-const contentPages = [];
-const contentAssets = new Set();
-const pagesByUrl = new Map();
-const pagesByFile = new Map();
 const errors = [];
 let internalLinks = 0;
 let externalLinks = 0;
 let protocolLinks = 0;
 
-collectContent();
-
-for (const file of markdownFiles) {
-  checkMarkdownFile(file);
-}
+for (const file of markdownFiles) checkMarkdownFile(file);
 
 console.log(`${markdownFiles.length} Markdown file(s) scanned`);
 console.log(`${internalLinks} internal link(s) checked`);
@@ -31,272 +41,52 @@ console.log(`${externalLinks} external link(s) inventoried`);
 console.log(`${protocolLinks} protocol link(s) inventoried`);
 
 if (errors.length) {
-  for (const error of errors) {
-    console.error(`error: ${error}`);
-  }
+  for (const error of errors) console.error(`error: ${error}`);
   process.exitCode = 1;
-}
-
-function collectContent() {
-  for (const file of listFiles(contentDir)) {
-    const relative = slash(path.relative(contentDir, file));
-    if (relative.endsWith(".md")) {
-      const raw = readFileSync(file, "utf8");
-      const parsed = parseFrontmatter(raw, relative);
-      if (parsed.data.draft === true) continue;
-
-      const slug = slugFromFile(relative);
-      const page = {
-        file,
-        relative,
-        sourceDir: slash(path.dirname(relative)),
-        url: slug ? `/${slug}/` : "/",
-        anchors: collectAnchors(parsed.content)
-      };
-
-      contentPages.push(page);
-      pagesByUrl.set(page.url, page);
-      pagesByFile.set(slash(path.relative(root, file)), page);
-      continue;
-    }
-
-    contentAssets.add(`/${relative}`);
-  }
 }
 
 function checkMarkdownFile(file) {
   const raw = readFileSync(file, "utf8");
   const source = slash(path.relative(root, file));
   const parsed = parseFrontmatter(raw, source);
-  const tokens = md.parse(parsed.content, {});
-  const page = pagesByFile.get(slash(path.relative(root, file))) ?? null;
+  const page = pagesByFile.get(path.resolve(file)) ?? null;
   const baseDir = page ? path.join(contentDir, page.sourceDir) : path.dirname(file);
 
-  for (const token of tokens) {
-    collectTokenLinks(token, source, baseDir, page);
+  for (const target of collectMarkdownTargets(parsed.content)) {
+    checkTarget(target, source, baseDir, page);
   }
 }
 
-function collectTokenLinks(token, source, baseDir, page) {
-  const line = token.map ? token.map[0] + 1 : 1;
+function checkTarget(target, source, baseDir, page) {
+  const rawTarget = String(target.value ?? "").trim();
+  if (!rawTarget || rawTarget.startsWith("javascript:")) return;
 
-  if (token.type === "inline" && token.children) {
-    for (const child of token.children) {
-      collectTokenLinks({ ...child, map: token.map }, source, baseDir, page);
-    }
-    return;
-  }
-
-  if (token.type === "link_open") {
-    checkTarget(getAttr(token, "href"), source, line, baseDir, page, "link");
-    return;
-  }
-
-  if (token.type === "image") {
-    checkTarget(getAttr(token, "src"), source, line, baseDir, page, "image");
-    return;
-  }
-
-  if (token.type === "html_inline" || token.type === "html_block") {
-    for (const target of htmlTargets(token.content)) {
-      checkTarget(target.value, source, line, baseDir, page, target.kind);
-    }
-  }
-}
-
-function checkTarget(rawTarget, source, line, baseDir, page, kind) {
-  if (!rawTarget) return;
-
-  const target = decodeTarget(rawTarget.trim());
-  if (!target || target.startsWith("javascript:")) return;
-
-  if (/^https?:\/\//i.test(target)) {
+  if (/^https?:\/\//i.test(rawTarget)) {
     externalLinks += 1;
     return;
   }
 
-  if (/^[a-z][a-z0-9+.-]*:/i.test(target)) {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(rawTarget)) {
     protocolLinks += 1;
     return;
   }
 
+  if (!isInternalTarget(rawTarget)) return;
   internalLinks += 1;
-  const [targetPath, rawFragment = ""] = target.split("#");
-  const fragment = rawFragment.trim();
-  const resolved = resolveInternalTarget(targetPath, baseDir, page);
+
+  const { path: targetPath, fragment } = splitTarget(rawTarget);
+  const resolved = target.shortcode
+    ? resolver.resolveRef(targetPath, page)
+    : resolver.resolve(targetPath, baseDir, page);
 
   if (!resolved) {
-    errors.push(`${source}:${line}: missing ${kind} target ${rawTarget}`);
+    errors.push(`${source}:${target.line}: missing ${target.kind} target ${rawTarget}`);
     return;
   }
 
   if (fragment && resolved.page && !resolved.page.anchors.has(slugify(fragment))) {
-    errors.push(`${source}:${line}: missing anchor #${fragment} in ${resolved.page.url}`);
+    errors.push(`${source}:${target.line}: missing anchor #${fragment} in ${resolved.page.url}`);
   }
-}
-
-function resolveInternalTarget(targetPath, baseDir, page) {
-  if (!targetPath) return page ? { page } : { file: baseDir };
-
-  if (targetPath.startsWith("/")) {
-    return resolveAbsoluteSiteTarget(targetPath);
-  }
-
-  const absolute = path.resolve(baseDir, targetPath);
-  const contentRelative = slash(path.relative(contentDir, absolute));
-  if (!contentRelative.startsWith("../")) {
-    const contentTarget = resolveContentRelative(contentRelative);
-    if (contentTarget) return contentTarget;
-  }
-
-  const repoRelative = slash(path.relative(root, absolute));
-  if (!repoRelative.startsWith("../") && existsSync(absolute)) {
-    return { file: absolute };
-  }
-
-  return null;
-}
-
-function resolveAbsoluteSiteTarget(targetPath) {
-  const normalized = withSlashes(targetPath.replace(/\/index\.html?$/i, ""));
-  if (pagesByUrl.has(normalized)) return { page: pagesByUrl.get(normalized) };
-
-  const assetPath = `/${targetPath.replace(/^\/+/, "")}`;
-  if (contentAssets.has(assetPath)) return { file: path.join(contentDir, assetPath.slice(1)) };
-
-  return null;
-}
-
-function resolveContentRelative(relative) {
-  const normalized = slash(path.posix.normalize(relative));
-  const absolute = path.join(contentDir, normalized);
-
-  if (normalized.endsWith(".md")) {
-    const page = pagesByFile.get(`content/${normalized}`);
-    if (page) return { page };
-  }
-
-  if (existsSync(absolute) && statSync(absolute).isFile()) {
-    return { file: absolute };
-  }
-
-  const indexFile = path.join(absolute, "index.md");
-  if (existsSync(indexFile)) {
-    const page = pagesByFile.get(slash(path.relative(root, indexFile)));
-    if (page) return { page };
-  }
-
-  const sectionFile = path.join(absolute, "_index.md");
-  if (existsSync(sectionFile)) {
-    const page = pagesByFile.get(slash(path.relative(root, sectionFile)));
-    if (page) return { page };
-  }
-
-  const url = withSlashes(normalized.replace(/\.html?$/i, ""));
-  if (pagesByUrl.has(url)) return { page: pagesByUrl.get(url) };
-
-  return null;
-}
-
-function collectAnchors(source) {
-  const anchors = new Set();
-  const tokens = md.parse(source, {});
-
-  for (let index = 0; index < tokens.length; index += 1) {
-    const token = tokens[index];
-    if (token.type === "heading_open") {
-      const id = token.attrGet("id");
-      if (id) anchors.add(slugify(id));
-
-      const inline = tokens[index + 1];
-      if (inline?.type === "inline") {
-        anchors.add(slugify(inline.content));
-      }
-    }
-
-    if (token.type === "html_block" || token.type === "html_inline") {
-      for (const id of htmlIds(token.content)) {
-        anchors.add(slugify(id));
-      }
-    }
-  }
-
-  return anchors;
-}
-
-function htmlTargets(value) {
-  const targets = [];
-  const matcher = /\b(href|src)\s*=\s*(['"])(.*?)\2/gi;
-  let match;
-  while ((match = matcher.exec(value))) {
-    targets.push({ kind: match[1].toLowerCase() === "src" ? "asset" : "link", value: match[3] });
-  }
-  return targets;
-}
-
-function getAttr(token, name) {
-  if (typeof token.attrGet === "function") return token.attrGet(name);
-  return token.attrs?.find(([key]) => key === name)?.[1] ?? "";
-}
-
-function htmlIds(value) {
-  const ids = [];
-  const matcher = /\bid\s*=\s*(['"])(.*?)\1/gi;
-  let match;
-  while ((match = matcher.exec(value))) {
-    ids.push(match[2]);
-  }
-  return ids;
-}
-
-function decodeTarget(value) {
-  const [pathPart, fragmentPart] = value.split("#");
-  const decodedPath = decodeUriPath(pathPart.split("?")[0]);
-  const fragment = fragmentPart === undefined ? "" : `#${fragmentPart}`;
-  return `${decodedPath}${fragment}`;
-}
-
-function decodeUriPath(value) {
-  try {
-    return decodeURI(value);
-  } catch {
-    return value;
-  }
-}
-
-function listMarkdown(dir) {
-  return listFiles(dir).filter((file) => file.endsWith(".md"));
-}
-
-function listFiles(dir) {
-  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-    const absolute = path.join(dir, entry.name);
-    if (entry.isDirectory()) return listFiles(absolute);
-    return [absolute];
-  });
-}
-
-function slugFromFile(relativeFile) {
-  if (relativeFile === "_index.md") return "";
-  return relativeFile
-    .replace(/\/index\.md$/i, "")
-    .replace(/\/_index\.md$/i, "")
-    .replace(/\.md$/i, "")
-    .replace(/^_index$/i, "");
-}
-
-function slugify(value) {
-  return String(value)
-    .toLowerCase()
-    .trim()
-    .replace(/['"`]/g, "")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
-
-function withSlashes(value) {
-  if (value === "/") return "/";
-  return `/${value.replace(/^\/+|\/+$/g, "")}/`;
 }
 
 function slash(value) {

--- a/scripts/content-graph.mjs
+++ b/scripts/content-graph.mjs
@@ -1,0 +1,160 @@
+import { appendFile, mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { buildContentGraph } from "../src/lib/content-graph.mjs";
+
+export const DEFAULT_OUTPUT = ".reports/content-graph.md";
+export const DEFAULT_JSON_OUTPUT = ".reports/content-graph.json";
+export const DEFAULT_LIMIT = 100;
+
+export function createGraphReport(graph, options = {}) {
+  const limit = options.limit ?? DEFAULT_LIMIT;
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new Error("report limit must be a positive integer");
+  }
+
+  const pages = [...graph.pages]
+    .sort(comparePages)
+    .map((page) => ({
+      url: page.url,
+      title: page.title,
+      section: page.section || "index",
+      relativeFile: page.relativeFile
+    }));
+  const edges = [...graph.edges]
+    .sort(compareEdges)
+    .map((edge) => ({
+      fromUrl: edge.fromUrl,
+      toUrl: edge.toUrl,
+      kind: edge.kind,
+      line: edge.line,
+      rawTarget: edge.rawTarget,
+      fragment: edge.fragment
+    }));
+
+  return {
+    version: 1,
+    summary: graph.summary,
+    pages,
+    edges,
+    unresolvedReferences: [...graph.unresolved].sort(compareUnresolved),
+    isolatedPages: [...graph.isolatedPages].sort(),
+    isolatedPreview: [...graph.isolatedPages].sort().slice(0, limit)
+  };
+}
+
+export function renderMarkdown(report) {
+  const { summary } = report;
+  const preview = report.isolatedPreview
+    .map((url) => {
+      const page = report.pages.find((item) => item.url === url);
+      return `- [${page?.title ?? url}](${url})`;
+    })
+    .join("\n");
+  const omitted = report.isolatedPages.length - report.isolatedPreview.length;
+
+  return [
+    "# Content relationship graph",
+    "",
+    `- Pages: ${summary.pages}`,
+    `- Explicit reference occurrences: ${summary.referenceCount}`,
+    `- Unique page-to-page references: ${summary.uniqueReferenceCount}`,
+    `- Unresolved explicit page references: ${report.unresolvedReferences.length}`,
+    `- Pages with outgoing references: ${summary.pagesWithOutgoing}`,
+    `- Pages with incoming references: ${summary.pagesWithIncoming}`,
+    `- Pages without explicit references: ${summary.isolatedPages}`,
+    "",
+    `## Pages without explicit references (showing ${report.isolatedPreview.length})`,
+    "",
+    preview || "- None",
+    omitted > 0 ? `\n_${omitted} additional page(s) are listed in the JSON report._` : "",
+    "",
+    "The graph is report-only. Hierarchy and shared tags remain valid navigation edges even when a page has no explicit Markdown reference.",
+    ""
+  ].join("\n");
+}
+
+export async function run(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  const graph = buildContentGraph({
+    contentRoot: path.join(process.cwd(), "content"),
+    strict: false
+  });
+  const report = createGraphReport(graph, options);
+  const markdown = renderMarkdown(report);
+  const json = `${JSON.stringify(report, null, 2)}\n`;
+
+  await Promise.all([
+    writeReport(options.output, markdown),
+    writeReport(options.json, json)
+  ]);
+
+  if (options.summaryFile) {
+    await appendFile(options.summaryFile, renderSummary(report));
+  }
+
+  console.log(
+    `Content graph: ${report.summary.pages} pages, ${report.summary.uniqueReferenceCount} unique reference(s), ${report.summary.isolatedPages} page(s) without explicit references`
+  );
+  return report;
+}
+
+function parseArgs(argv) {
+  const options = {
+    output: DEFAULT_OUTPUT,
+    json: DEFAULT_JSON_OUTPUT,
+    limit: DEFAULT_LIMIT,
+    summaryFile: ""
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--output") options.output = argv[++index];
+    else if (argument === "--json") options.json = argv[++index];
+    else if (argument === "--limit") options.limit = Number(argv[++index]);
+    else if (argument === "--summary-file") options.summaryFile = argv[++index];
+    else throw new Error(`unknown option ${argument}`);
+  }
+
+  return options;
+}
+
+async function writeReport(file, contents) {
+  await mkdir(path.dirname(path.resolve(file)), { recursive: true });
+  await writeFile(file, contents, "utf8");
+}
+
+function renderSummary(report) {
+  return [
+    "### Content relationship graph",
+    `- ${report.summary.pages} pages indexed; ${report.summary.uniqueReferenceCount} unique explicit page reference(s).`,
+    `- ${report.unresolvedReferences.length} unresolved explicit page reference(s).`,
+    `- ${report.summary.isolatedPages} page(s) have no explicit inbound or outbound reference; hierarchy and tags remain available navigation edges.`,
+    ""
+  ].join("\n");
+}
+
+function comparePages(a, b) {
+  return a.title.localeCompare(b.title, "en", { sensitivity: "base", numeric: true }) ||
+    a.url.localeCompare(b.url);
+}
+
+function compareEdges(a, b) {
+  return a.fromUrl.localeCompare(b.fromUrl) ||
+    a.toUrl.localeCompare(b.toUrl) ||
+    a.line - b.line ||
+    a.rawTarget.localeCompare(b.rawTarget);
+}
+
+function compareUnresolved(a, b) {
+  return a.source.localeCompare(b.source) ||
+    a.line - b.line ||
+    a.target.localeCompare(b.target);
+}
+
+if (pathToFileURL(path.resolve(process.argv[1] ?? "")).href === import.meta.url) {
+  run().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/src/lib/content-graph.mjs
+++ b/src/lib/content-graph.mjs
@@ -1,0 +1,468 @@
+import fs from "node:fs";
+import path from "node:path";
+import MarkdownIt from "markdown-it";
+import { buildContentIndex } from "./content-index.mjs";
+
+const markdown = new MarkdownIt({ html: true, linkify: false });
+const collator = new Intl.Collator("en", { sensitivity: "base", numeric: true });
+
+/**
+ * Build the visible content relationship graph from the canonical content index.
+ *
+ * The graph deliberately records only explicit page-to-page references. Hierarchy
+ * and tag relationships are derived by the runtime so every edge has one clear
+ * meaning and link validation can share the exact same resolver.
+ */
+export function buildContentGraph(options = {}) {
+  const contentRoot = path.resolve(
+    options.contentRoot ?? path.join(process.cwd(), "content")
+  );
+  const root = path.resolve(options.root ?? path.dirname(contentRoot));
+  const index =
+    options.index ??
+    buildContentIndex({
+      contentRoot,
+      strict: options.strict ?? true
+    });
+  const pages = options.pages ?? index.pages;
+  const resolver = createContentResolver({
+    root,
+    contentRoot,
+    pages,
+    assets: options.assets
+  });
+  const edges = [];
+  const unresolved = [];
+
+  for (const page of pages) {
+    const baseDir = path.join(contentRoot, page.sourceDir || "");
+    for (const target of collectMarkdownTargets(page.body)) {
+      if (target.kind !== "link" || !isInternalTarget(target.value)) continue;
+
+      const parsed = splitTarget(target.value);
+      const resolved = target.shortcode
+        ? resolver.resolveRef(parsed.path, page)
+        : resolver.resolve(parsed.path, baseDir, page);
+      if (resolved?.file) continue;
+      if (!resolved?.page) {
+        unresolved.push({
+          source: page.relativeFile,
+          line: target.line,
+          target: target.value
+        });
+        continue;
+      }
+
+      edges.push({
+        fromUrl: page.url,
+        toUrl: resolved.page.url,
+        kind: "reference",
+        line: target.line,
+        rawTarget: target.value,
+        fragment: parsed.fragment
+      });
+    }
+  }
+
+  const outgoing = new Map();
+  const incoming = new Map();
+  for (const page of pages) {
+    outgoing.set(page.url, []);
+    incoming.set(page.url, []);
+  }
+
+  for (const edge of edges) {
+    outgoing.get(edge.fromUrl)?.push(edge);
+    incoming.get(edge.toUrl)?.push(edge);
+  }
+
+  for (const list of [...outgoing.values(), ...incoming.values()]) {
+    list.sort((a, b) =>
+      a.toUrl.localeCompare(b.toUrl) ||
+      a.fromUrl.localeCompare(b.fromUrl) ||
+      a.line - b.line ||
+      a.rawTarget.localeCompare(b.rawTarget)
+    );
+  }
+
+  const pagesWithOutgoing = [...outgoing.values()].filter((list) => list.length > 0).length;
+  const pagesWithIncoming = [...incoming.values()].filter((list) => list.length > 0).length;
+  const isolatedPages = pages
+    .filter((page) => !outgoing.get(page.url)?.length && !incoming.get(page.url)?.length)
+    .sort(comparePages)
+    .map((page) => page.url);
+  const uniqueEdges = new Set(edges.map((edge) => `${edge.fromUrl}\u0000${edge.toUrl}`));
+
+  return {
+    contentRoot,
+    root,
+    pages,
+    resolver,
+    edges,
+    outgoing,
+    incoming,
+    unresolved,
+    summary: {
+      pages: pages.length,
+      referenceCount: edges.length,
+      uniqueReferenceCount: uniqueEdges.size,
+      pagesWithOutgoing,
+      pagesWithIncoming,
+      isolatedPages: isolatedPages.length
+    },
+    isolatedPages
+  };
+}
+
+/**
+ * Create the shared filesystem/site resolver used by graph building and checks.
+ */
+export function createContentResolver({
+  root = process.cwd(),
+  contentRoot = path.join(root, "content"),
+  pages = [],
+  assets
+} = {}) {
+  const resolvedRoot = path.resolve(root);
+  const resolvedContentRoot = path.resolve(contentRoot);
+  const pagesByUrl = new Map(pages.map((page) => [page.url, page]));
+  const pagesByFile = new Map();
+  const refsByKey = buildRefMap(pages);
+
+  for (const page of pages) {
+    pagesByFile.set(path.resolve(resolvedContentRoot, page.relativeFile), page);
+    if (page.file) pagesByFile.set(path.resolve(page.file), page);
+  }
+
+  const contentAssets = assets ?? collectContentAssets(resolvedContentRoot);
+
+  return {
+    pagesByUrl,
+    pagesByFile,
+    contentAssets,
+    resolve(targetPath, baseDir, page) {
+      return resolveInternalTarget(targetPath, {
+        root: resolvedRoot,
+        contentRoot: resolvedContentRoot,
+        pagesByUrl,
+        pagesByFile,
+        contentAssets,
+        baseDir,
+        page
+      });
+    },
+    resolveRef(target, page) {
+      return resolveRefTarget(target, page, pagesByUrl, refsByKey);
+    }
+  };
+}
+
+/**
+ * Extract Markdown and inline HTML links while retaining body-relative line data.
+ */
+export function collectMarkdownTargets(source) {
+  const targets = [];
+  const tokens = markdown.parse(String(source), {});
+
+  for (const token of tokens) collectTokenTargets(token, targets);
+  collectShortcodeTargets(String(source), targets);
+  return targets;
+}
+
+export function collectAnchors(source) {
+  const anchors = new Set();
+  const tokens = markdown.parse(String(source), {});
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token.type === "heading_open") {
+      const id = token.attrGet("id");
+      if (id) anchors.add(slugify(id));
+
+      const inline = tokens[index + 1];
+      if (inline?.type === "inline") anchors.add(slugify(inline.content));
+    }
+
+    if (token.type === "html_block" || token.type === "html_inline") {
+      for (const id of htmlIds(token.content)) anchors.add(slugify(id));
+    }
+  }
+
+  return anchors;
+}
+
+export function resolveInternalTarget(targetPath, context) {
+  const {
+    root,
+    contentRoot,
+    pagesByUrl,
+    pagesByFile,
+    contentAssets,
+    baseDir,
+    page
+  } = context;
+
+  if (!targetPath) return page ? { page } : { file: baseDir };
+
+  if (targetPath.startsWith("/")) {
+    return resolveAbsoluteSiteTarget(targetPath, pagesByUrl, contentAssets, contentRoot);
+  }
+
+  const absolute = path.resolve(baseDir, targetPath);
+  const contentRelative = slash(path.relative(contentRoot, absolute));
+  if (contentRelative !== ".." && !contentRelative.startsWith("../")) {
+    const contentTarget = resolveContentRelative(
+      contentRelative,
+      contentRoot,
+      pagesByFile,
+      pagesByUrl
+    );
+    if (contentTarget) return contentTarget;
+  }
+
+  const repoRelative = slash(path.relative(root, absolute));
+  if (repoRelative !== ".." && !repoRelative.startsWith("../") && isFile(absolute)) {
+    return { file: absolute };
+  }
+
+  return null;
+}
+
+export function splitTarget(value) {
+  const target = String(value).trim();
+  const hashIndex = target.indexOf("#");
+  const pathPart = hashIndex === -1 ? target : target.slice(0, hashIndex);
+  const fragment = hashIndex === -1 ? "" : target.slice(hashIndex + 1).trim();
+  const queryIndex = pathPart.indexOf("?");
+  const cleanPath = queryIndex === -1 ? pathPart : pathPart.slice(0, queryIndex);
+
+  return {
+    path: decodeUriPath(cleanPath),
+    fragment,
+    target
+  };
+}
+
+export function isInternalTarget(value) {
+  const target = String(value ?? "").trim();
+  return Boolean(target) &&
+    !target.startsWith("javascript:") &&
+    !/^https?:\/\//i.test(target) &&
+    !/^[a-z][a-z0-9+.-]*:/i.test(target);
+}
+
+export function slugify(value) {
+  return String(value)
+    .toLowerCase()
+    .trim()
+    .replace(/[\'"`]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function withSlashes(value) {
+  if (value === "/") return "/";
+  return `/${value.replace(/^\/+|\/+$/g, "")}/`;
+}
+
+export function slash(value) {
+  return String(value).replace(/\\/g, "/");
+}
+
+function collectTokenTargets(token, targets) {
+  const line = token.map ? token.map[0] + 1 : 1;
+
+  if (token.type === "inline" && token.children) {
+    for (const child of token.children) collectTokenTargets({ ...child, map: token.map }, targets);
+    return;
+  }
+
+  if (token.type === "link_open") {
+    targets.push({ kind: "link", value: getAttr(token, "href"), line, shortcode: false });
+    return;
+  }
+
+  if (token.type === "image") {
+    targets.push({ kind: "asset", value: getAttr(token, "src"), line });
+    return;
+  }
+
+  if (token.type === "html_inline" || token.type === "html_block") {
+    for (const target of htmlTargets(token.content)) targets.push({ ...target, line });
+  }
+}
+
+function collectShortcodeTargets(source, targets) {
+  const matcher = /\{\{[<%]\s*ref\s+"?([^"%>}]+)"?\s*[>%]\}\}/g;
+  let match;
+  while ((match = matcher.exec(source))) {
+    targets.push({
+      kind: "link",
+      value: match[1].trim(),
+      line: source.slice(0, match.index).split("\n").length,
+      shortcode: true
+    });
+  }
+}
+
+function resolveAbsoluteSiteTarget(targetPath, pagesByUrl, contentAssets, contentRoot) {
+  const normalized = withSlashes(targetPath.replace(/\/index\.html?$/i, ""));
+  if (pagesByUrl.has(normalized)) return { page: pagesByUrl.get(normalized) };
+
+  const assetPath = `/${targetPath.replace(/^\/+/, "")}`;
+  if (contentAssets.has(assetPath)) {
+    return { file: path.join(contentRoot, assetPath.slice(1)) };
+  }
+
+  return null;
+}
+
+function resolveContentRelative(relative, contentRoot, pagesByFile, pagesByUrl) {
+  const normalized = slash(path.posix.normalize(relative));
+  const absolute = path.join(contentRoot, normalized);
+
+  if (normalized.endsWith(".md")) {
+    const page = pagesByFile.get(path.resolve(absolute));
+    if (page) return { page };
+  }
+
+  if (isFile(absolute)) return { file: absolute };
+
+  const indexFile = path.join(absolute, "index.md");
+  const indexPage = pagesByFile.get(path.resolve(indexFile));
+  if (indexPage) return { page: indexPage };
+
+  const sectionFile = path.join(absolute, "_index.md");
+  const sectionPage = pagesByFile.get(path.resolve(sectionFile));
+  if (sectionPage) return { page: sectionPage };
+
+  const url = withSlashes(normalized.replace(/\.html?$/i, ""));
+  if (pagesByUrl.has(url)) return { page: pagesByUrl.get(url) };
+
+  return null;
+}
+
+function collectContentAssets(directory) {
+  if (!fs.existsSync(directory)) return new Set();
+  return new Set(
+    listFiles(directory)
+      .filter((file) => !file.endsWith(".md"))
+      .map((file) => `/${slash(path.relative(directory, file))}`)
+  );
+}
+
+function listFiles(directory) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const absolute = path.join(directory, entry.name);
+    if (entry.isDirectory()) return listFiles(absolute);
+    return [absolute];
+  });
+}
+
+function htmlTargets(value) {
+  const targets = [];
+  const matcher = /\b(href|src)\s*=\s*(['"])(.*?)\2/gi;
+  let match;
+  while ((match = matcher.exec(value))) {
+    targets.push({
+      kind: match[1].toLowerCase() === "src" ? "asset" : "link",
+      value: match[3],
+      shortcode: false
+    });
+  }
+  return targets;
+}
+
+function resolveRefTarget(target, page, pagesByUrl, refsByKey) {
+  const clean = String(target)
+    .replace(/\\/g, "/")
+    .replace(/(^"|"$)/g, "")
+    .replace(/\.md$/i, "")
+    .replace(/\/index$/i, "")
+    .replace(/\/_index$/i, "")
+    .replace(/^\/+|\/+$/g, "");
+
+  if (!clean) return page ? { page } : null;
+
+  const candidates = [
+    `/${clean}/`,
+    `/${slash(path.posix.normalize(path.posix.join(page?.sourceDir ?? "", clean)))}/`,
+    `/${slash(path.posix.normalize(clean))}/`
+  ].map(withSlashes);
+
+  for (const candidate of candidates) {
+    const resolved = pagesByUrl.get(candidate);
+    if (resolved) return { page: resolved };
+  }
+
+  const basename = clean.split("/").filter(Boolean).pop()?.toLowerCase();
+  if (!basename) return null;
+  const matches = refsByKey.get(basename) ?? [];
+  if (matches.length === 1) return { page: matches[0] };
+
+  const nearest = matches
+    .map((match) => ({ match, score: commonPrefix(page?.slug, match.slug) }))
+    .sort((a, b) => b.score - a.score || comparePages(a.match, b.match))[0]?.match;
+  return nearest ? { page: nearest } : null;
+}
+
+function buildRefMap(pages) {
+  const map = new Map();
+  for (const page of pages) {
+    const keys = new Set([
+      page.slug?.split("/").filter(Boolean).pop()?.toLowerCase(),
+      page.relativeFile?.replace(/\/_?index\.md$/i, "").split("/").pop()?.toLowerCase(),
+      slugify(page.title)
+    ]);
+
+    for (const key of keys) {
+      if (!key) continue;
+      const matches = map.get(key) ?? [];
+      matches.push(page);
+      map.set(key, matches);
+    }
+  }
+  return map;
+}
+
+function commonPrefix(a, b) {
+  const left = String(a ?? "").split("/").filter(Boolean);
+  const right = String(b ?? "").split("/").filter(Boolean);
+  let count = 0;
+  while (left[count] && right[count] && left[count] === right[count]) count += 1;
+  return count;
+}
+
+function htmlIds(value) {
+  const ids = [];
+  const matcher = /\bid\s*=\s*(['"])(.*?)\1/gi;
+  let match;
+  while ((match = matcher.exec(value))) ids.push(match[2]);
+  return ids;
+}
+
+function getAttr(token, name) {
+  if (typeof token.attrGet === "function") return token.attrGet(name) ?? "";
+  return token.attrs?.find(([key]) => key === name)?.[1] ?? "";
+}
+
+function decodeUriPath(value) {
+  try {
+    return decodeURI(value);
+  } catch {
+    return value;
+  }
+}
+
+function isFile(value) {
+  try {
+    return fs.statSync(value).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function comparePages(a, b) {
+  return collator.compare(String(a.title ?? ""), String(b.title ?? "")) ||
+    collator.compare(a.url, b.url);
+}

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import MarkdownIt from "markdown-it";
 import anchor from "markdown-it-anchor";
 import { buildContentIndex, normalizeWeight } from "./content-index.mjs";
+import { buildContentGraph } from "./content-graph.mjs";
 import { normalizeDate } from "./date.mjs";
 import {
   canonicalTag,
@@ -36,9 +37,17 @@ export type KbPage = {
   breadcrumbs: KbPage[];
 };
 
+export type PageConnection = {
+  page: KbPage;
+  kind: "reference" | "referenced-by" | "parent" | "child" | "related";
+  reason: string;
+  score: number;
+};
+
 let cache: KbPage[] | null = null;
 let urlMap: Map<string, KbPage> | null = null;
 let refMap: Map<string, KbPage[]> | null = null;
+let contentGraph: ContentGraph | null = null;
 
 type ContentRecord = {
   file: string;
@@ -56,6 +65,28 @@ type ContentRecord = {
 
 type ContentIndex = {
   pages: ContentRecord[];
+};
+
+type ContentGraphEdge = {
+  fromUrl: string;
+  toUrl: string;
+  kind: "reference";
+  line: number;
+  rawTarget: string;
+  fragment: string;
+};
+
+type ContentGraph = {
+  outgoing: Map<string, ContentGraphEdge[]>;
+  incoming: Map<string, ContentGraphEdge[]>;
+  summary: {
+    pages: number;
+    referenceCount: number;
+    uniqueReferenceCount: number;
+    pagesWithOutgoing: number;
+    pagesWithIncoming: number;
+    isolatedPages: number;
+  };
 };
 
 const md = new MarkdownIt({
@@ -84,6 +115,7 @@ export function getPages() {
   if (cache) return cache;
 
   const index = buildContentIndex({ contentRoot }) as ContentIndex;
+  const graph = buildContentGraph({ contentRoot, index }) as ContentGraph;
   const pageMap = new Map(index.pages.map((record) => [record.url, toKbPage(record)]));
   const pages = [...pageMap.values()];
   const byUrl = new Map(pages.map((page) => [page.url, page]));
@@ -103,6 +135,7 @@ export function getPages() {
   cache = pages;
   urlMap = byUrl;
   refMap = buildRefMap(pages);
+  contentGraph = graph;
   return pages;
 }
 
@@ -159,6 +192,73 @@ export function getRelatedPages(page: KbPage, limit = 4) {
     .sort((a, b) => b.score - a.score || sortPages(a.candidate, b.candidate))
     .slice(0, limit)
     .map(({ candidate }) => candidate);
+}
+
+export function getPageConnections(page: KbPage, limit = 8): PageConnection[] {
+  getPages();
+  const candidates = new Map<string, PageConnection>();
+  const kindOrder = new Map<PageConnection["kind"], number>([
+    ["reference", 0],
+    ["referenced-by", 1],
+    ["child", 2],
+    ["parent", 3],
+    ["related", 4]
+  ]);
+
+  const add = (
+    candidate: KbPage | undefined,
+    kind: PageConnection["kind"],
+    reason: string,
+    score: number
+  ) => {
+    if (!candidate || candidate.url === page.url || candidate.frontmatter.hidden === true) return;
+    const existing = candidates.get(candidate.url);
+    if (!existing || score > existing.score) {
+      candidates.set(candidate.url, { page: candidate, kind, reason, score });
+    }
+  };
+
+  for (const edge of contentGraph?.outgoing.get(page.url) ?? []) {
+    add(urlMap?.get(edge.toUrl), "reference", "Explicit reference", 100);
+  }
+  for (const edge of contentGraph?.incoming.get(page.url) ?? []) {
+    add(urlMap?.get(edge.fromUrl), "referenced-by", "References this note", 90);
+  }
+
+  if (page.parentUrl && page.parentUrl !== "/") {
+    add(urlMap?.get(page.parentUrl), "parent", "Parent section", 70);
+  }
+  for (const child of page.children) {
+    add(child, "child", "Child note", 65);
+  }
+
+  for (const related of getRelatedPages(page, Math.max(limit * 2, 12))) {
+    const sharedTags = related.tags.filter((tag) =>
+      page.tags.some((pageTag) => tagSlug(pageTag) === tagSlug(tag))
+    ).length;
+    add(related, "related", "Shared tags", 20 + sharedTags);
+  }
+
+  return [...candidates.values()]
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        (kindOrder.get(a.kind) ?? 99) - (kindOrder.get(b.kind) ?? 99) ||
+        sortPages(a.page, b.page)
+    )
+    .slice(0, Math.max(1, limit));
+}
+
+export function getContentGraphSummary() {
+  getPages();
+  return contentGraph?.summary ?? {
+    pages: 0,
+    referenceCount: 0,
+    uniqueReferenceCount: 0,
+    pagesWithOutgoing: 0,
+    pagesWithIncoming: 0,
+    isolatedPages: 0
+  };
 }
 
 export function getPageNeighbors(page: KbPage) {

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -1,6 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
-import { getPageNeighbors, getPages, getRelatedPages, renderPage } from "@lib/content";
+import { getPageConnections, getPageNeighbors, getPages, renderPage } from "@lib/content";
 
 export function getStaticPaths() {
   return getPages()
@@ -13,7 +13,7 @@ export function getStaticPaths() {
 
 const { page } = Astro.props;
 const html = renderPage(page);
-const relatedPages = getRelatedPages(page);
+const connections = getPageConnections(page);
 const neighbors = getPageNeighbors(page);
 ---
 
@@ -41,13 +41,15 @@ const neighbors = getPageNeighbors(page);
     </nav>
   )}
 
-  {relatedPages.length > 0 && (
+  {connections.length > 0 && (
     <section class="related-pages" aria-labelledby="related-pages-title">
-      <h2 id="related-pages-title">Related notes</h2>
+      <h2 id="related-pages-title">Explore from here</h2>
+      <p class="connection-intro">Follow references, sections, and shared topics to continue the investigation.</p>
       <div class="related-grid">
-        {relatedPages.map((related) => (
+        {connections.map(({ page: related, reason }) => (
           <a href={related.url}>
-            {related.title}
+            <small>{reason}</small>
+            <strong>{related.title}</strong>
             {related.description && <p>{related.description}</p>}
           </a>
         ))}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -916,10 +916,22 @@ h1 {
   font-size: 20px;
 }
 
+.connection-intro {
+  margin: -4px 0 14px;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.45;
+}
+
 .related-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 10px;
+}
+
+.related-pages a strong {
+  display: block;
+  color: var(--text);
 }
 
 .related-pages p {

--- a/test/content-graph.test.mjs
+++ b/test/content-graph.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { buildContentGraph, collectMarkdownTargets } from "../src/lib/content-graph.mjs";
+import { createGraphReport, renderMarkdown } from "../scripts/content-graph.mjs";
+
+test("builds deterministic references and reverse edges without treating assets as pages", async () => {
+  const contentRoot = await mkdtemp(path.join(os.tmpdir(), "kb-content-graph-"));
+
+  try {
+    await mkdir(path.join(contentRoot, "tools", "alpha", "files"), { recursive: true });
+    await mkdir(path.join(contentRoot, "tools", "beta"), { recursive: true });
+    await mkdir(path.join(contentRoot, "tools", "gamma"), { recursive: true });
+    await writeFile(path.join(contentRoot, "_index.md"), "---\ntitle: Root\n---\n");
+    await writeFile(
+      path.join(contentRoot, "tools", "_index.md"),
+      "---\ntitle: Tools\n---\n"
+    );
+    await writeFile(
+      path.join(contentRoot, "tools", "alpha", "index.md"),
+      `---\ntitle: Alpha\n---\n[Beta](../beta/#overview)\n{{< ref "gamma" >}}\n![asset](files/sample.txt)\n`
+    );
+    await writeFile(
+      path.join(contentRoot, "tools", "beta", "index.md"),
+      "---\ntitle: Beta\n---\n## Overview\n"
+    );
+    await writeFile(
+      path.join(contentRoot, "tools", "gamma", "index.md"),
+      "---\ntitle: Gamma\n---\n"
+    );
+    await writeFile(path.join(contentRoot, "tools", "alpha", "files", "sample.txt"), "asset");
+
+    const targets = collectMarkdownTargets(
+      "[Beta](../beta/#overview)\n{{< ref \"gamma\" >}}\n![asset](files/sample.txt)"
+    );
+    assert.deepEqual(
+      targets.map(({ kind, value, shortcode }) => ({ kind, value, shortcode })),
+      [
+        { kind: "link", value: "../beta/#overview", shortcode: false },
+        { kind: "asset", value: "files/sample.txt", shortcode: undefined },
+        { kind: "link", value: "gamma", shortcode: true }
+      ]
+    );
+
+    const graph = buildContentGraph({ contentRoot });
+    assert.equal(graph.summary.pages, 5);
+    assert.equal(graph.summary.referenceCount, 2);
+    assert.equal(graph.summary.uniqueReferenceCount, 2);
+    assert.equal(graph.unresolved.length, 0);
+    assert.deepEqual(
+      graph.edges.map(({ fromUrl, toUrl, fragment }) => ({ fromUrl, toUrl, fragment })),
+      [
+        { fromUrl: "/tools/alpha/", toUrl: "/tools/beta/", fragment: "overview" },
+        { fromUrl: "/tools/alpha/", toUrl: "/tools/gamma/", fragment: "" }
+      ]
+    );
+    assert.equal(graph.incoming.get("/tools/beta/").length, 1);
+    assert.deepEqual(graph.isolatedPages, ["/", "/tools/"]);
+
+    const report = createGraphReport(graph, { limit: 1 });
+    assert.equal(report.pages.length, 5);
+    assert.equal(report.edges.length, 2);
+    assert.equal(report.unresolvedReferences.length, 0);
+    assert.deepEqual(report.isolatedPreview, ["/"]);
+    assert.match(renderMarkdown(report), /Pages without explicit references/);
+  } finally {
+    await rm(contentRoot, { recursive: true, force: true });
+  }
+});
+
+test("represents the full publishable corpus and resolves every page reference", () => {
+  const graph = buildContentGraph();
+  const urls = new Set(graph.pages.map((page) => page.url));
+
+  assert.equal(graph.summary.pages, 751);
+  assert.equal(graph.unresolved.length, 0);
+  assert.ok(graph.summary.referenceCount > 0);
+  assert.ok(graph.edges.every((edge) => urls.has(edge.fromUrl) && urls.has(edge.toUrl)));
+  assert.equal(new Set(graph.pages.map((page) => page.url)).size, 751);
+});


### PR DESCRIPTION
## Summary

- Add a canonical content relationship graph for Markdown links and `ref` shortcodes.
- Add deterministic incoming/outgoing connections to every content page.
- Replace tag-only related notes with an accessible “Explore from here” navigator.
- Add `npm run content:graph` with complete JSON and maintainer Markdown reports.
- Upload graph reports with the weekly content freshness artifacts.
- Refactor link validation to use the shared resolver and add full-corpus graph tests.

## Why

The knowledge base has 751 pages but only a small set of explicit page-to-page references. The navigator makes existing hierarchy, references, and shared tags useful as a guided investigation path without inventing frontmatter or requiring an editorial backfill.

## Validation

- `npm test` — 21 tests passed.
- `npm run check` — Astro diagnostics clean.
- `npm run check:content` and `npm run check:links` — clean.
- `npm run build` — 751 pages indexed successfully.
- Asset, smoke, and audit checks passed.
- `npm run doctor` remains environment-blocked because the shell has Node 24.18.1 while `.node-version` requires 24.19.0.
