### PR TITLE
Harden dependency maintenance and CI pins

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,13 +26,13 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone this repo
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .node-version
           cache: npm

--- a/.github/workflows/content-review.yml
+++ b/.github/workflows/content-review.yml
@@ -10,13 +10,13 @@ permissions:
 
 jobs:
   review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone this repo
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .node-version
           cache: npm
@@ -47,7 +47,7 @@ jobs:
 
       - name: Upload content review reports
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: content-review-queue
           path: |

--- a/.github/workflows/external-links.yml
+++ b/.github/workflows/external-links.yml
@@ -10,13 +10,13 @@ permissions:
 
 jobs:
   links:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone this repo
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .node-version
 
@@ -25,7 +25,7 @@ jobs:
 
       - name: Upload link health report
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: external-link-health
           path: .reports/external-links.md

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -24,23 +24,23 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone this repo
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Lint content Markdown
-        uses: rvben/rumdl@4997ff07b63c7a54d6a495ebcd3ce7f23ee1173f # v0
+        uses: rvben/rumdl@4997ff07b63c7a54d6a495ebcd3ce7f23ee1173f # v0.2.55
         with:
-          version: '0.2.48'
+          version: '0.2.55'
           path: 'content/'
           config: '.markdownlint.yml'
           report-type: annotations
 
       - name: Lint README
-        uses: rvben/rumdl@4997ff07b63c7a54d6a495ebcd3ce7f23ee1173f # v0
+        uses: rvben/rumdl@4997ff07b63c7a54d6a495ebcd3ce7f23ee1173f # v0.2.55
         with:
-          version: '0.2.48'
+          version: '0.2.55'
           path: 'README.md'
           config: '.markdownlint.yml'
           report-type: annotations

--- a/.github/workflows/sysinternals.yml
+++ b/.github/workflows/sysinternals.yml
@@ -10,13 +10,13 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone this repo
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .node-version
           cache: npm

--- a/content/tools/windows/w10privacy/index.md
+++ b/content/tools/windows/w10privacy/index.md
@@ -1,7 +1,7 @@
 ---
 title : "W10privacy"
 # pre : ' '
-description : "Privacy made ​​easy."
+description : "Privacy made easy."
 date : 2021-08-19T11:08:35+02:00
 # hidden : true
 # draft : true
@@ -11,7 +11,7 @@ weight : 330
 
 ---
 
-"Privacy made ​​easy"
+"Privacy made easy"
 
 The by default highly questionable set options concerning privacy and data protection in Windows 10 brought me to the idea to develop this program. Microsoft generously enableseverybody to change the concerning settings, but hides them in countless menus, where a normal user does not want to search for!
 

--- a/renovate.json
+++ b/renovate.json
@@ -28,5 +28,19 @@
       ],
       "groupName": "GitHub Actions dependencies"
     }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^\\.github\\/workflows\\/linting\\.yml$/"
+      ],
+      "matchStrings": [
+        "version:\\s*['\"](?<currentValue>[^'\"]+)['\"]"
+      ],
+      "depNameTemplate": "rvben/rumdl",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver-coerced"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Pin all workflows to `ubuntu-24.04` for reproducible runner behavior.
- Update the rumdl action input from `0.2.48` to `0.2.55` and keep its release comment aligned with the reviewed SHA.
- Add a Renovate custom manager for the rumdl version input, which the standard GitHub Actions manager does not track.
- Remove the confirmed zero-width Unicode characters from the W10Privacy page.

## Dependency assessment

No npm manifest or lockfile update is included. The audit found no known vulnerabilities and all direct dependencies are at their latest compatible versions. TypeScript 7 is blocked by the current `@astrojs/check` peer range, while js-yaml 5 would violate Astro's `^4.3.0` dependency contract; both remain deferred pending upstream support.

## Validation

- `npm run validate` (33 tests; Astro check/build, content/link/assets/smoke/audit checks)
- `npm run check:outdated`
- `npm run audit:known`
- `npm run sysinternals:check`
- JSON/YAML parsing and Renovate custom-manager match checks
- `git diff --check`
