### PR TITLE
Maintain Renovate lockfiles weekly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigests",
+    ":maintainLockFilesWeekly"
   ],
   "labels": [
     "dependencies"


### PR DESCRIPTION
## What changed

- Enable Renovate's weekly lockfile maintenance preset.

## Why

The repository already receives direct dependency updates, but lockfile maintenance was not explicitly scheduled. Weekly refreshes keep transitive dependency versions and fixes current without manually changing the lockfile or broadening compatibility constraints.

## Validation

- `npm run validate`
- 33 tests passed
- Astro checks and build passed
- Content, link, smoke, asset, and known-audit checks passed
