### PR TITLE
Surface external link health reports

### DIFF
--- a/.github/workflows/external-links.yml
+++ b/.github/workflows/external-links.yml
@@ -21,11 +21,19 @@ jobs:
           node-version-file: .node-version
 
       - name: Check external links
-        run: node scripts/check-external-links.mjs --output .reports/external-links.md
+        run: |
+          npm run check:external-links -- \
+            --output .reports/external-links.md \
+            --json .reports/external-links.json \
+            --summary-file "$GITHUB_STEP_SUMMARY"
 
       - name: Upload link health report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: external-link-health
-          path: .reports/external-links.md
+          path: |
+            .reports/external-links.md
+            .reports/external-links.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ npm run check
 npm run check:assets
 npm run check:content
 npm run check:links
+npm run check:external-links
 npm run audit:known
 npm run sysinternals:check
 npm run content:review
@@ -55,8 +56,11 @@ downloadable assets. External links are inventoried without network calls.
 `npm test` runs focused parser and content-contract tests. `npm run doctor`
 checks the Node.js version, required project paths, and local npm availability.
 
-The scheduled `Check external links` workflow creates a report of reachable
-external URLs without blocking content builds.
+`npm run check:external-links` checks reachable external URLs and writes
+Markdown plus complete JSON reports under `.reports/`. The scheduled and
+manual `Check external links` workflow uploads both reports and adds the check
+counts plus a short list of failures to the GitHub job summary. It remains
+report-only: an unreachable external URL does not block content builds.
 
 `npm run content:review` scans all publishable pages and writes a maintainer-only
 review queue to `.reports/content-review.md` plus a complete JSON report at

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "check:assets": "node scripts/check-content-assets.mjs",
     "check:content": "node scripts/check-content.mjs",
     "check:links": "node scripts/check-links.mjs",
+    "check:external-links": "node scripts/check-external-links.mjs",
     "check:outdated": "node scripts/check-outdated.mjs",
     "audit:known": "node scripts/check-audit.mjs",
     "doctor": "node scripts/doctor.mjs",

--- a/scripts/check-external-links.mjs
+++ b/scripts/check-external-links.mjs
@@ -1,56 +1,220 @@
-import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
-const root = process.cwd();
-const args = process.argv.slice(2);
-const output = valueAfter("--output") ?? "external-links-report.md";
-const timeoutMs = Number(valueAfter("--timeout") ?? 10000);
-const concurrency = Math.max(1, Number(valueAfter("--concurrency") ?? 8));
-const urls = new Set();
+export const DEFAULT_OUTPUT = ".reports/external-links.md";
+export const DEFAULT_JSON_OUTPUT = ".reports/external-links.json";
+export const DEFAULT_TIMEOUT_MS = 10_000;
+export const DEFAULT_CONCURRENCY = 8;
+export const MAX_SUMMARY_FAILURES = 5;
 
-await collectMarkdown(path.join(root, "content"));
-await collectFile(path.join(root, "README.md"));
+const collator = new Intl.Collator("en", { sensitivity: "base", numeric: true });
 
-const uniqueUrls = [...urls].sort();
-const results = [];
-let cursor = 0;
+export async function collectUrls(root = process.cwd()) {
+  const urls = new Set();
+  await collectMarkdown(path.join(root, "content"), urls);
+  await collectFile(path.join(root, "README.md"), urls);
+  return [...urls].sort(compareUrls);
+}
 
-async function worker() {
-  while (cursor < uniqueUrls.length) {
-    const index = cursor++;
-    results[index] = await checkUrl(uniqueUrls[index]);
+export async function checkUrls(
+  urls,
+  {
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    concurrency = DEFAULT_CONCURRENCY,
+    fetchImpl = globalThis.fetch
+  } = {}
+) {
+  if (!Number.isInteger(timeoutMs) || timeoutMs < 1) {
+    throw new Error("timeout must be a positive integer");
+  }
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new Error("concurrency must be a positive integer");
+  }
+
+  const uniqueUrls = [...new Set(urls)].sort(compareUrls);
+  const results = [];
+  let cursor = 0;
+
+  async function worker() {
+    while (cursor < uniqueUrls.length) {
+      const index = cursor++;
+      results[index] = await checkUrl(uniqueUrls[index], { timeoutMs, fetchImpl });
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, uniqueUrls.length) }, worker)
+  );
+  return results.sort(compareResults);
+}
+
+export async function checkUrl(
+  url,
+  { timeoutMs = DEFAULT_TIMEOUT_MS, fetchImpl = globalThis.fetch } = {}
+) {
+  try {
+    const head = await request(url, "HEAD", { timeoutMs, fetchImpl });
+    if (head.status !== 405 && head.status !== 403) return { url, status: head.status };
+    const get = await request(url, "GET", { timeoutMs, fetchImpl });
+    return { url, status: get.status };
+  } catch (error) {
+    return { url, error: error.message };
   }
 }
 
-await Promise.all(Array.from({ length: Math.min(concurrency, uniqueUrls.length) }, worker));
-results.sort((a, b) => a.url.localeCompare(b.url));
+export function createExternalLinkReport(results, options = {}) {
+  const orderedResults = results.map(normalizeResult).sort(compareResults);
+  const failures = orderedResults.filter(isFailure);
 
-const failures = results.filter((result) => result.error || result.status >= 400);
-const lines = [
-  "# External link health",
-  "",
-  `Checked: ${results.length}`,
-  `Generated: ${new Date().toISOString()}`,
-  `Failures: ${failures.length}`,
-  ""
-];
+  return {
+    version: 1,
+    generatedAt: options.generatedAt ?? new Date().toISOString(),
+    timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    concurrency: options.concurrency ?? DEFAULT_CONCURRENCY,
+    summary: {
+      checked: orderedResults.length,
+      passed: orderedResults.length - failures.length,
+      failed: failures.length
+    },
+    results: orderedResults
+  };
+}
 
-if (failures.length) {
-  lines.push("| URL | Result | Detail |", "| --- | --- | --- |");
+export function renderMarkdown(report) {
+  const failures = report.results.filter(isFailure);
+  const lines = [
+    "# External link health",
+    "",
+    `Checked: ${report.summary.checked}`,
+    `Generated: ${report.generatedAt}`,
+    `Passed: ${report.summary.passed}`,
+    `Failures: ${report.summary.failed}`,
+    ""
+  ];
+
+  if (!failures.length) {
+    lines.push("All checked external links responded successfully.", "");
+    return `${lines.join("\n")}\n`;
+  }
+
+  lines.push(
+    "## Failures",
+    "",
+    "| URL | Result | Detail |",
+    "| --- | --- | --- |"
+  );
   for (const result of failures) {
     const detail = result.error ?? `HTTP ${result.status}`;
-    lines.push(`| ${result.url} | failed | ${detail.replaceAll("|", "\\|")} |`);
+    lines.push(
+      `| ${escapeTable(result.url)} | failed | ${escapeTable(detail)} |`
+    );
   }
-} else {
-  lines.push("All checked external links responded successfully.");
+
+  return `${lines.join("\n")}\n`;
 }
 
-await mkdir(path.dirname(path.resolve(root, output)), { recursive: true });
-await writeFile(path.resolve(root, output), `${lines.join("\n")}\n`);
+export function renderSummary(report) {
+  const failures = report.results.filter(isFailure);
+  const lines = [
+    "### External link health",
+    `- Checked: ${report.summary.checked}`,
+    `- Passed: ${report.summary.passed}`,
+    `- Failed: ${report.summary.failed}`
+  ];
 
-console.log(`Checked ${results.length} external link(s); ${failures.length} failure(s)`);
+  if (failures.length) {
+    lines.push(`- First failures (of ${failures.length}):`);
+    for (const result of failures.slice(0, MAX_SUMMARY_FAILURES)) {
+      const detail = result.error ?? `HTTP ${result.status}`;
+      lines.push(`  - \`${escapeInline(result.url)}\`: ${escapeInline(detail)}`);
+    }
+    if (failures.length > MAX_SUMMARY_FAILURES) {
+      lines.push(`  - ${failures.length - MAX_SUMMARY_FAILURES} more in the uploaded report.`);
+    }
+  } else {
+    lines.push("- All checked URLs responded successfully.");
+  }
 
-async function collectMarkdown(directory) {
+  return lines.join("\n");
+}
+
+export async function run(
+  argv = process.argv.slice(2),
+  { root = process.cwd(), fetchImpl = globalThis.fetch, generatedAt } = {}
+) {
+  const options = parseArguments(argv);
+  const urls = await collectUrls(root);
+  const results = await checkUrls(urls, {
+    timeoutMs: options.timeoutMs,
+    concurrency: options.concurrency,
+    fetchImpl
+  });
+  const report = createExternalLinkReport(results, {
+    generatedAt,
+    timeoutMs: options.timeoutMs,
+    concurrency: options.concurrency
+  });
+
+  await Promise.all([
+    writeReport(path.resolve(root, options.output), renderMarkdown(report)),
+    writeReport(
+      path.resolve(root, options.json),
+      `${JSON.stringify(report, null, 2)}\n`
+    )
+  ]);
+
+  if (options.summaryFile) {
+    const summaryFile = path.resolve(root, options.summaryFile);
+    await mkdir(path.dirname(summaryFile), { recursive: true });
+    await appendFile(summaryFile, `${renderSummary(report)}\n`);
+  }
+
+  console.log(
+    `External links: ${report.summary.checked} checked; ${report.summary.failed} failure(s)`
+  );
+  return report;
+}
+
+export function parseArguments(argv = []) {
+  const options = {
+    output: DEFAULT_OUTPUT,
+    json: DEFAULT_JSON_OUTPUT,
+    summaryFile: undefined,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    concurrency: DEFAULT_CONCURRENCY
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    const [flag, inlineValue] = argument.split("=", 2);
+    const value = inlineValue ?? argv[++index];
+
+    switch (flag) {
+      case "--output":
+        options.output = requireValue(flag, value);
+        break;
+      case "--json":
+        options.json = requireValue(flag, value);
+        break;
+      case "--summary-file":
+        options.summaryFile = requireValue(flag, value);
+        break;
+      case "--timeout":
+        options.timeoutMs = parsePositiveInteger(flag, value);
+        break;
+      case "--concurrency":
+        options.concurrency = parsePositiveInteger(flag, value);
+        break;
+      default:
+        throw new Error(`Unknown option ${flag}`);
+    }
+  }
+
+  return options;
+}
+
+async function collectMarkdown(directory, urls) {
   let entries;
   try {
     entries = await readdir(directory, { withFileTypes: true });
@@ -60,13 +224,19 @@ async function collectMarkdown(directory) {
 
   for (const entry of entries) {
     const absolute = path.join(directory, entry.name);
-    if (entry.isDirectory()) await collectMarkdown(absolute);
-    else if (entry.name.endsWith(".md")) await collectFile(absolute);
+    if (entry.isDirectory()) await collectMarkdown(absolute, urls);
+    else if (entry.name.endsWith(".md")) await collectFile(absolute, urls);
   }
 }
 
-async function collectFile(file) {
-  const source = await readFile(file, "utf8");
+async function collectFile(file, urls) {
+  let source;
+  try {
+    source = await readFile(file, "utf8");
+  } catch {
+    return;
+  }
+
   const matches = source.matchAll(/https?:\/\/[^\s<>"')\]]+/gi);
   for (const match of matches) {
     const clean = match[0].replace(/[.,;:!?]+$/, "");
@@ -74,19 +244,10 @@ async function collectFile(file) {
   }
 }
 
-async function checkUrl(url) {
-  try {
-    const head = await request(url, "HEAD");
-    if (head.status !== 405 && head.status !== 403) return { url, status: head.status };
-    const get = await request(url, "GET");
-    return { url, status: get.status };
-  } catch (error) {
-    return { url, error: error.message };
-  }
-}
+async function request(url, method, { timeoutMs, fetchImpl }) {
+  if (typeof fetchImpl !== "function") throw new Error("fetch is unavailable");
 
-async function request(url, method) {
-  const response = await fetch(url, {
+  const response = await fetchImpl(url, {
     method,
     redirect: "follow",
     signal: AbortSignal.timeout(timeoutMs),
@@ -99,7 +260,61 @@ async function request(url, method) {
   return response;
 }
 
-function valueAfter(name) {
-  const index = args.indexOf(name);
-  return index >= 0 ? args[index + 1] : undefined;
+function normalizeResult(result) {
+  return {
+    url: String(result.url),
+    status: Number.isInteger(result.status) ? result.status : null,
+    error: result.error ? String(result.error) : null
+  };
+}
+
+function isFailure(result) {
+  return Boolean(result.error) || !Number.isInteger(result.status) || result.status >= 400;
+}
+
+function compareResults(a, b) {
+  return collator.compare(a.url, b.url);
+}
+
+function compareUrls(a, b) {
+  return collator.compare(a, b);
+}
+
+async function writeReport(file, contents) {
+  await mkdir(path.dirname(file), { recursive: true });
+  await writeFile(file, contents, "utf8");
+}
+
+function requireValue(flag, value) {
+  if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value`);
+  return value;
+}
+
+function parsePositiveInteger(flag, value) {
+  const parsed = Number(requireValue(flag, value));
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${flag} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function escapeTable(value) {
+  return String(value).replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
+function escapeInline(value) {
+  return String(value).replaceAll("`", "\\`").replaceAll("\n", " ");
+}
+
+const isMain =
+  process.argv[1] &&
+  pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+
+if (isMain) {
+  try {
+    await run();
+  } catch (error) {
+    console.error(`error: ${error.message}`);
+    process.exitCode = 1;
+  }
 }

--- a/test/external-links.test.mjs
+++ b/test/external-links.test.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  checkUrl,
+  createExternalLinkReport,
+  parseArguments,
+  renderMarkdown,
+  renderSummary,
+  run
+} from "../scripts/check-external-links.mjs";
+
+test("creates a complete, deterministically ordered external-link report", () => {
+  const report = createExternalLinkReport(
+    [
+      { url: "https://z.example", status: 503 },
+      { url: "https://a.example", status: 200 },
+      { url: "https://m.example", error: "request timed out" }
+    ],
+    {
+      generatedAt: "2026-08-14T00:00:00.000Z",
+      timeoutMs: 5000,
+      concurrency: 2
+    }
+  );
+
+  assert.deepEqual(report.summary, { checked: 3, passed: 1, failed: 2 });
+  assert.deepEqual(
+    report.results.map(({ url }) => url),
+    ["https://a.example", "https://m.example", "https://z.example"]
+  );
+  assert.equal(report.results[1].status, null);
+  assert.equal(report.generatedAt, "2026-08-14T00:00:00.000Z");
+  assert.match(renderMarkdown(report), /Failures: 2/);
+  assert.match(renderMarkdown(report), /https:\/\/z\.example/);
+  assert.match(renderSummary(report), /First failures \(of 2\)/);
+});
+
+test("renders a concise success summary without failure rows", () => {
+  const report = createExternalLinkReport(
+    [{ url: "https://example.test", status: 204 }],
+    { generatedAt: "2026-08-14T00:00:00.000Z" }
+  );
+
+  assert.match(renderMarkdown(report), /All checked external links responded successfully/);
+  assert.doesNotMatch(renderMarkdown(report), /## Failures/);
+  assert.match(renderSummary(report), /All checked URLs responded successfully/);
+});
+
+test("falls back from HEAD to GET for servers that reject HEAD", async () => {
+  const methods = [];
+  const result = await checkUrl("https://example.test", {
+    timeoutMs: 1000,
+    fetchImpl: async (_url, options) => {
+      methods.push(options.method);
+      return {
+        status: options.method === "HEAD" ? 405 : 200,
+        body: { cancel() {} }
+      };
+    }
+  });
+
+  assert.deepEqual(methods, ["HEAD", "GET"]);
+  assert.deepEqual(result, { url: "https://example.test", status: 200 });
+});
+
+test("parses report, summary, timeout, and concurrency options", () => {
+  assert.deepEqual(
+    parseArguments([
+      "--output",
+      "reports/links.md",
+      "--json=reports/links.json",
+      "--summary-file",
+      "summary.md",
+      "--timeout",
+      "5000",
+      "--concurrency=3"
+    ]),
+    {
+      output: "reports/links.md",
+      json: "reports/links.json",
+      summaryFile: "summary.md",
+      timeoutMs: 5000,
+      concurrency: 3
+    }
+  );
+});
+
+test("run writes Markdown, complete JSON, and the requested summary", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "kb-external-links-"));
+
+  try {
+    await mkdir(path.join(root, "content", "tools", "example"), { recursive: true });
+    await writeFile(
+      path.join(root, "content", "tools", "example", "index.md"),
+      "---\ntitle: Example\n---\n[Good](https://good.example)\n[Bad](https://bad.example)\n"
+    );
+    await writeFile(path.join(root, "README.md"), "[Good](https://good.example)\n");
+
+    const report = await run(
+      [
+        "--output",
+        ".reports/links.md",
+        "--json",
+        ".reports/links.json",
+        "--summary-file",
+        ".reports/summary.md"
+      ],
+      {
+        root,
+        generatedAt: "2026-08-14T00:00:00.000Z",
+        fetchImpl: async (url, options) => ({
+          status: url.includes("bad") ? 404 : 200,
+          body: { cancel() {} },
+          headers: options
+        })
+      }
+    );
+
+    const json = JSON.parse(await readFile(path.join(root, ".reports/links.json"), "utf8"));
+    const markdown = await readFile(path.join(root, ".reports/links.md"), "utf8");
+    const summary = await readFile(path.join(root, ".reports/summary.md"), "utf8");
+
+    assert.equal(report.summary.checked, 2);
+    assert.deepEqual(json.summary, { checked: 2, passed: 1, failed: 1 });
+    assert.equal(json.results.length, 2);
+    assert.match(markdown, /Failures: 1/);
+    assert.match(summary, /External link health/);
+    assert.match(summary, /https:\/\/bad\.example/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What changed

- Add `npm run check:external-links` with complete JSON and improved Markdown output.
- Append concise counts and the first failures to the GitHub Actions job summary.
- Upload both report formats from the scheduled/manual workflow.
- Add deterministic tests for ordering, HEAD-to-GET fallback, argument parsing, and report writing.
- Document the local command and report-only policy.

## Why

External-link checks previously wrote only a Markdown artifact, so maintainers had to open the artifact to see whether failures existed. The workflow now provides immediate visibility while remaining report-only: unreachable URLs do not block content builds.

## Validation

- `npm run validate`
- 38 tests passed
- Live corpus check: 2,616 URLs checked; 1,932 passed and 684 reported failures
- Workflow and package JSON/YAML parsing passed
