### PR TITLE
Add browser-level accessibility smoke tests

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -1,0 +1,81 @@
+name: Browser accessibility smoke tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/accessibility.yml"
+      - ".node-version"
+      - "astro.config.mjs"
+      - "package.json"
+      - "package-lock.json"
+      - "playwright.config.mjs"
+      - "src/**"
+      - "static/**"
+      - "content/**"
+      - "scripts/**"
+      - "tests/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/accessibility.yml"
+      - ".node-version"
+      - "astro.config.mjs"
+      - "package.json"
+      - "package-lock.json"
+      - "playwright.config.mjs"
+      - "src/**"
+      - "static/**"
+      - "content/**"
+      - "scripts/**"
+      - "tests/**"
+
+permissions:
+  contents: read
+
+jobs:
+  accessibility:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Clone this repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium for browser tests
+        run: npx playwright install --with-deps chromium
+
+      - name: Run browser accessibility smoke tests
+        run: npm run test:a11y
+
+      - name: Add job summary
+        if: always()
+        run: |
+          {
+            echo "## Browser accessibility smoke tests"
+            echo
+            echo "Checked representative routes plus keyboard search and mobile navigation with Playwright and Axe."
+            echo
+            echo "Result: ${{ job.status }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload browser test artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: accessibility-playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,5 @@ codex.resume
 .astro/
 dist/
 node_modules/
+playwright-report/
+test-results/

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ npm test
 npm run doctor
 npm run build
 npm run smoke
+npm run test:a11y
 npm run validate
 ```
 
@@ -55,6 +56,12 @@ downloadable assets. External links are inventoried without network calls.
 
 `npm test` runs focused parser and content-contract tests. `npm run doctor`
 checks the Node.js version, required project paths, and local npm availability.
+`npm run test:a11y` builds the deployable static site, serves it with Astro
+Preview, and runs the browser-level Playwright/Axe smoke suite against
+representative routes and keyboard interactions. The `Browser accessibility
+smoke tests` workflow runs the same check on pull requests, pushes to `main`,
+and manual dispatches. For a first local run, install the test browser once
+with `npx playwright install chromium`.
 
 `npm run check:external-links` checks reachable external URLs and writes
 Markdown plus complete JSON reports under `.reports/`. The scheduled and

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,10 @@
         "pagefind": "^1.1.1",
         "typescript": "^6.0.0",
         "yaml": "^2.9.0"
+      },
+      "devDependencies": {
+        "@axe-core/playwright": "^4.13.0",
+        "@playwright/test": "^1.62.1"
       }
     },
     "node_modules/@astrojs/check": {
@@ -366,6 +370,19 @@
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.3"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.13.0.tgz",
+      "integrity": "sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.13.0"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -1803,6 +1820,22 @@
         "win32"
       ]
     },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.1.tgz",
@@ -2582,6 +2615,16 @@
         "@astrojs/markdown-remark": {
           "optional": true
         }
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/axobject-query": {
@@ -4278,6 +4321,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "content:graph": "node scripts/content-graph.mjs",
     "content:health": "node scripts/content-health.mjs",
     "test": "node --test test/*.test.mjs",
+    "test:a11y": "npm run build && playwright test --config=playwright.config.mjs",
     "sysinternals:check": "node scripts/sync-sysinternals.mjs --check",
     "sysinternals:refresh-manifest": "node scripts/sync-sysinternals.mjs --refresh-manifest",
     "sysinternals:sync": "node scripts/sync-sysinternals.mjs --write",
@@ -45,5 +46,9 @@
     "esbuild@0.28.2": true,
     "sharp@0.34.5": true,
     "fsevents@2.3.3": true
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "^4.13.0",
+    "@playwright/test": "^1.62.1"
   }
 }

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,24 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  testMatch: "**/*.spec.mjs",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI
+    ? [["github"], ["html", { outputFolder: "playwright-report", open: "never" }]]
+    : "list",
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:4321",
+    colorScheme: "dark",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure"
+  },
+  webServer: {
+    command: "npm run preview -- --host 127.0.0.1 --port 4321",
+    url: "http://127.0.0.1:4321/",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000
+  }
+});

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -196,7 +196,7 @@ function renderNav(items: KbPage[], level = 0): string {
           </select>
         </label>
       </div>
-      <div class="search-results" id="search-results" data-search-results aria-live="polite" aria-label="Search results"></div>
+      <div class="search-results" id="search-results" data-search-results role="region" aria-live="polite" aria-label="Search results"></div>
     </dialog>
 
     <script is:inline src="/js/kb-app.js" defer></script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7,7 +7,7 @@
   --line-soft: #182124;
   --text: #d8e2df;
   --muted: #849390;
-  --dim: #53615e;
+  --dim: #7f908c;
   --green: #35f29a;
   --cyan: #4cc9f0;
   --amber: #f9c74f;
@@ -847,7 +847,6 @@ h1 {
   color: var(--text);
   background: transparent;
   border: 0;
-  outline: 0;
   font-family: var(--mono);
   font-size: 22px;
 }

--- a/static/js/kb-app.js
+++ b/static/js/kb-app.js
@@ -1,6 +1,8 @@
 (() => {
   const body = document.body;
+  const sidebar = document.querySelector("#site-sidebar");
   const sidebarToggle = document.querySelector("[data-sidebar-toggle]");
+  const mobileSidebarQuery = window.matchMedia("(max-width: 940px)");
   const dialog = document.querySelector("[data-search-dialog]");
   const searchOpeners = document.querySelectorAll("[data-search-open]");
   const searchInput = document.querySelector("[data-search-input]");
@@ -13,9 +15,31 @@
   let activeResultIndex = -1;
   let lastFocusedElement = null;
 
+  const syncSidebarAccessibility = (isOpen = body.classList.contains("sidebar-open")) => {
+    if (!sidebar) return;
+
+    if (!mobileSidebarQuery.matches) {
+      sidebar.removeAttribute("aria-hidden");
+      sidebar.removeAttribute("inert");
+      return;
+    }
+
+    sidebar.setAttribute("aria-hidden", String(!isOpen));
+    if (isOpen) sidebar.removeAttribute("inert");
+    else sidebar.setAttribute("inert", "");
+  };
+
   sidebarToggle?.addEventListener("click", () => {
     const isOpen = body.classList.toggle("sidebar-open");
     sidebarToggle.setAttribute("aria-expanded", String(isOpen));
+    syncSidebarAccessibility(isOpen);
+  });
+
+  syncSidebarAccessibility();
+  mobileSidebarQuery.addEventListener?.("change", () => {
+    body.classList.remove("sidebar-open");
+    sidebarToggle?.setAttribute("aria-expanded", "false");
+    syncSidebarAccessibility(false);
   });
 
   document.addEventListener("click", (event) => {
@@ -23,6 +47,7 @@
     if (event.target.closest("#site-sidebar") || event.target.closest("[data-sidebar-toggle]")) return;
     body.classList.remove("sidebar-open");
     sidebarToggle?.setAttribute("aria-expanded", "false");
+    syncSidebarAccessibility(false);
   });
 
   document.querySelectorAll("pre").forEach((block) => {

--- a/tests/accessibility-smoke.spec.mjs
+++ b/tests/accessibility-smoke.spec.mjs
@@ -1,0 +1,77 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+const representativeRoutes = [
+  { path: "/", name: "home" },
+  { path: "/commands/", name: "section overview" },
+  { path: "/commands/unix/awk/", name: "content page" },
+  { path: "/tools/techniques/kerberoasting/", name: "tool technique page" },
+  { path: "/tags/", name: "tag index" }
+];
+
+for (const route of representativeRoutes) {
+  test(`${route.name} has no automated accessibility violations`, async ({ page }) => {
+    const response = await page.goto(route.path, { waitUntil: "networkidle" });
+
+    expect(response?.ok(), `${route.path} should return a successful response`).toBeTruthy();
+    await expect(page.locator("html")).toHaveAttribute("lang", "en");
+    await expect(page.locator("main#main-content")).toBeVisible();
+    await expect(page.locator("main h1")).toHaveCount(1);
+
+    const results = await new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa"]).analyze();
+    expect(results.violations).toEqual([]);
+  });
+}
+
+test("keyboard users can skip to content and operate search", async ({ page }) => {
+  await page.goto("/", { waitUntil: "networkidle" });
+
+  await page.keyboard.press("Tab");
+  await expect(page.locator(".skip-link")).toBeFocused();
+  await expect(page.locator(".skip-link")).toBeVisible();
+
+  await page.locator("[data-search-open]").focus();
+  await page.keyboard.press("/");
+  const dialog = page.locator("[data-search-dialog]");
+  await expect(dialog).toBeVisible();
+  const searchInput = page.locator("[data-search-input]");
+  await expect(searchInput).toBeFocused();
+  await expect(searchInput).toHaveCSS("outline-style", "solid");
+
+  const dialogResults = await new AxeBuilder({ page }).include("[data-search-dialog]").analyze();
+  expect(dialogResults.violations).toEqual([]);
+
+  await searchInput.fill("awk");
+  await expect(dialog.locator(".search-results a").first()).toBeVisible();
+
+  await page.keyboard.press("Escape");
+  await expect(dialog).not.toBeVisible();
+  await expect(page.locator("[data-search-open]")).toBeFocused();
+
+  await page.locator("[data-search-open]").click();
+  await page.locator('[data-search-dialog] button[aria-label="Close search"]').click();
+  await expect(dialog).not.toBeVisible();
+  await expect(page.locator("[data-search-open]")).toBeFocused();
+});
+
+test("mobile navigation exposes its expanded state", async ({ page }) => {
+  await page.setViewportSize({ width: 640, height: 800 });
+  await page.goto("/", { waitUntil: "networkidle" });
+
+  const toggle = page.locator("[data-sidebar-toggle]");
+  const sidebar = page.locator("#site-sidebar");
+  await expect(toggle).toBeVisible();
+  await expect(toggle).toHaveAttribute("aria-expanded", "false");
+  await expect(sidebar).toHaveAttribute("aria-hidden", "true");
+  await expect(sidebar).toHaveAttribute("inert", "");
+
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-expanded", "true");
+  await expect(sidebar).toHaveAttribute("aria-hidden", "false");
+  await expect(sidebar).not.toHaveAttribute("inert");
+
+  await page.mouse.click(620, 700);
+  await expect(toggle).toHaveAttribute("aria-expanded", "false");
+  await expect(sidebar).toHaveAttribute("aria-hidden", "true");
+  await expect(sidebar).toHaveAttribute("inert", "");
+});


### PR DESCRIPTION
## What changed

- Add Playwright and Axe smoke tests for representative knowledge-base routes, keyboard search, Pagefind results, focus styling, and mobile navigation.
- Add a dedicated `npm run test:a11y` command and pinned-node GitHub Actions workflow with Chromium installation, job summary, and downloadable Playwright artifacts.
- Fix the contrast and ARIA issues surfaced by the browser checks, restore the search focus outline, and remove the collapsed mobile sidebar from the keyboard tree with `aria-hidden` and `inert`.
- Document local usage and ignore generated browser-test artifacts.

## Why

The knowledge base needs a repeatable browser-level accessibility signal in addition to static checks. This exercises the deployable Astro preview output and catches regressions in rendered semantics, keyboard focus, dynamic search, and responsive navigation.

## Validation

- `npm run test:a11y` — 7 tests passed.
- `npm run validate` — passed.
- `npm ci --dry-run` — passed.
- Workflow YAML parsed locally.

The first local browser run requires `npx playwright install chromium`; CI installs Chromium automatically.
